### PR TITLE
Allow for configurable API key

### DIFF
--- a/oidc-controller/src/VCAuthn/Controllers/WebHookController.cs
+++ b/oidc-controller/src/VCAuthn/Controllers/WebHookController.cs
@@ -28,7 +28,7 @@ namespace VCAuthn.Controllers
         }
         
         
-        [HttpPost("{apiKey}/{topic}")]
+        [HttpPost("{apiKey}/topic/{topic}")]
         public async Task<ActionResult> GetTopicUpdate([FromRoute]string apiKey, [FromRoute]string topic, [FromBody]PresentationUpdate update)
         {
             if (!String.Equals(_config.GetValue<string>("ApiKey"), apiKey))

--- a/oidc-controller/src/VCAuthn/Security/ApiKeyAuthenticationHandler.cs
+++ b/oidc-controller/src/VCAuthn/Security/ApiKeyAuthenticationHandler.cs
@@ -25,6 +25,16 @@ namespace VCAuthn.Security
 
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
         {
+            if (string.IsNullOrEmpty(_apiKey))
+            {
+                var identity = new ClaimsIdentity(new List<Claim>(), Options.AuthenticationType);
+                var identities = new List<ClaimsIdentity> { identity };
+                var principal = new ClaimsPrincipal(identities);
+                var ticket = new AuthenticationTicket(principal, Options.Scheme);
+
+                return Task.FromResult(AuthenticateResult.Success(ticket));
+            }
+
             if (!Request.Headers.TryGetValue(ApiKeyHeaderName, out var apiKeyHeaderValues))
             {
                 return Task.FromResult(AuthenticateResult.NoResult());

--- a/oidc-controller/src/VCAuthn/Security/ApiKeyAuthenticationOptions.cs
+++ b/oidc-controller/src/VCAuthn/Security/ApiKeyAuthenticationOptions.cs
@@ -5,7 +5,7 @@ namespace VCAuthn.Security
     public class ApiKeyAuthenticationOptions : AuthenticationSchemeOptions
     {
         public const string DefaultScheme = "API Key";
-        public string Key = "default";
+        public string Key;
         public string Scheme => DefaultScheme;
         public string AuthenticationType = DefaultScheme;
     }


### PR DESCRIPTION
- Allows for the oidc controller to run without an api-key if it is not specified
- Fixes the webhook endpoint format for ACA-Py

Signed-off-by: Tobias Looker <tplooker@gmail.com>