### PR TITLE
Allow webhook functionality in insecure mode

### DIFF
--- a/docker/docker-compose.local-debug.yml
+++ b/docker/docker-compose.local-debug.yml
@@ -23,4 +23,4 @@ services:
     ports:
       - 5678:5678 
       - 5679:5679
-    command: [ "start", "-it", "http", "0.0.0.0", "5679", "-ot", "http",  "--log-level", "DEBUG", "--webhook-url", "https://localhost:5001", "--admin", "0.0.0.0", "5678", "--admin-api-key", "test", "--seed", "000000000000000000000000Steward1" ]
+    command: [ "start", "-it", "http", "0.0.0.0", "5679", "-ot", "http",  "--log-level", "DEBUG", "--webhook-url", "https://localhost:5001", "--admin", "0.0.0.0", "5678", "--admin-insecure-mode", "test", "--seed", "000000000000000000000000Steward1" ]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -76,7 +76,7 @@ services:
         --admin '0.0.0.0' ${AGENT_ADMIN_PORT} \
         --${ACAPY_ADMIN_MODE} \
         --label ${AGENT_NAME} \
-        --webhook-url ${IDENTITY_SERVER_URL}/${IDENTITY_SERVER_API_KEY}
+        --webhook-url ${IDENTITY_SERVER_WEB_HOOK_URL}
         --log-level debug",
       ]
 

--- a/docker/manage
+++ b/docker/manage
@@ -104,7 +104,11 @@ configureEnvironment() {
   # controller
   export IDENTITY_SERVER_URL="http://localhost:5000"
   export IDENTITY_SERVER_API_KEY="test-key"
+  export IDENTITY_SERVER_WEB_HOOK_URL=${IDENTITY_SERVER_URL}
   export IDENTITY_SERVER_SWAGGER_ENABLED=false
+  if [ ! -z "${IDENTITY_SERVER_API_KEY}" ]; then
+    IDENTITY_SERVER_WEB_HOOK_URL="${IDENTITY_SERVER_URL}/${IDENTITY_SERVER_API_KEY}"
+  fi
 
   # aca-py
   export AGENT_NAME="vc-oidc-controller-agent"

--- a/oidc-controller/src/VCAuthn/appsettings.json
+++ b/oidc-controller/src/VCAuthn/appsettings.json
@@ -9,7 +9,7 @@
   },
   "AllowedHosts": "*",
   "SwaggerEnabled": true,
-  "ApiKey": "default",
+  "ApiKey": "",
   "IdentityServer": {
     "ConnectionStrings": {
       "Database": "Host=localhost;Port=5432;Database=IdentityServer;User ID=identity;"
@@ -32,7 +32,7 @@
   },
   "ACAPY": {
     "AdminURL": "http://localhost:5678",
-    "AdminURLApiKey": "test",
+    "AdminURLApiKey": "",
     "AgentURL": "http://localhost:5679"
   },
   "UrlShortenerService": {


### PR DESCRIPTION
This PR allows the webhook endpoint to be used in insecure mode. It also relaxes the default settings in debug to use insecure mode.