### PR TITLE
Add support for custom label as referent in proof-request

### DIFF
--- a/oidc-controller/src/VCAuthn/Models/OptionalAttribute.cs
+++ b/oidc-controller/src/VCAuthn/Models/OptionalAttribute.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace VCAuthn.Models
+{
+    [AttributeUsage(AttributeTargets.Property,
+                Inherited = false,
+                AllowMultiple = false)]
+    internal sealed class OptionalAttribute : Attribute
+    {
+    }
+}

--- a/oidc-controller/src/VCAuthn/Models/RequestedAttribute.cs
+++ b/oidc-controller/src/VCAuthn/Models/RequestedAttribute.cs
@@ -8,6 +8,9 @@ namespace VCAuthn.Models
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        [JsonProperty("label"), Optional]
+        public string Label { get; set; }
+
         [JsonProperty("restrictions")]
         public List<AttributeFilter> Restrictions { get; set; }
     }

--- a/oidc-controller/src/VCAuthn/Models/RequestedPredicate.cs
+++ b/oidc-controller/src/VCAuthn/Models/RequestedPredicate.cs
@@ -8,6 +8,9 @@ namespace VCAuthn.Models
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        [JsonProperty("label"), Optional]
+        public string Label { get; set; }
+
         [JsonProperty("restrictions")]
         public List<AttributeFilter> Restrictions { get; set; }
 

--- a/oidc-controller/src/VCAuthn/Utils/PresentationRequestUtils.cs
+++ b/oidc-controller/src/VCAuthn/Utils/PresentationRequestUtils.cs
@@ -15,14 +15,32 @@ namespace VCAuthn.Utils
                 Name = configuration.Name
             };
 
-            configuration.RequestedAttributes.ForEach(delegate(RequestedAttribute reqAttribute)
+            configuration.RequestedAttributes.ForEach(delegate (RequestedAttribute reqAttribute)
             {
-                presentationRequest_1_0.RequestedAttributes.Add(Guid.NewGuid().ToString(), reqAttribute);
+                string referent = !String.IsNullOrEmpty(reqAttribute.Label) ? reqAttribute.Label : Guid.NewGuid().ToString();
+                reqAttribute.Label = null; // purge unsupported value from object that will be sent to aca-py
+                if (!presentationRequest_1_0.RequestedAttributes.ContainsKey(referent))
+                {
+                    presentationRequest_1_0.RequestedAttributes.Add(referent, reqAttribute);
+                }
+                else
+                {
+                    presentationRequest_1_0.RequestedAttributes.Add(disambiguateReferent(referent), reqAttribute);
+                }
             });
 
-            configuration.RequestedPredicates.ForEach(delegate(RequestedPredicate reqPredicate)
+            configuration.RequestedPredicates.ForEach(delegate (RequestedPredicate reqPredicate)
             {
-                presentationRequest_1_0.RequestedPredicates.Add(Guid.NewGuid().ToString(), reqPredicate);
+                string referent = !String.IsNullOrEmpty(reqPredicate.Label) ? reqPredicate.Label : Guid.NewGuid().ToString();
+                reqPredicate.Label = null; // purge unsupported value from object that will be sent to aca-py
+                if (!presentationRequest_1_0.RequestedPredicates.ContainsKey(referent))
+                {
+                    presentationRequest_1_0.RequestedPredicates.Add(referent, reqPredicate);
+                }
+                else
+                {
+                    presentationRequest_1_0.RequestedPredicates.Add(disambiguateReferent(referent), reqPredicate);
+                }
             });
 
             Dictionary<string, PresentationRequest_v_1_0> requestBody = new Dictionary<string, PresentationRequest_v_1_0>()
@@ -60,7 +78,7 @@ namespace VCAuthn.Utils
         {
             PresentationRequest presentationRequest = null;
 
-            presentationAttachments.ForEach(delegate(PresentationAttachment attachment)
+            presentationAttachments.ForEach(delegate (PresentationAttachment attachment)
             {
                 if (attachment.Id.Equals("libindy-request-presentation-0"))
                 {
@@ -75,6 +93,18 @@ namespace VCAuthn.Utils
         public static PresentationRequest toPresentationRequestObject(this string attachmentBase64Data)
         {
             return JsonConvert.DeserializeObject<PresentationRequest>(attachmentBase64Data.FromBase64());
+        }
+
+        private static String disambiguateReferent(this string referent)
+        {
+            int refIdx = 1;
+            if (referent.Split("~").Length > 1)
+            {
+                string[] splitReferent = referent.Split("~");
+                int oldIdx = Int32.Parse(splitReferent[splitReferent.Length - 1]);
+                refIdx += oldIdx;
+            }
+            return $"{referent}~{refIdx}";
         }
     }
 


### PR DESCRIPTION
Proof-Requests will now try to use the label defined in the configuration as referent, if available.
If the same label is used multiple times, the referent will try and disambiguate the repeated instances by adding a `~{counter}` suffix.
If no label is available, a GUID will be generated and used instead.

@andrewwhitehead I think using `~` as separator is fairly safe (maybe with the exception of very rare use cases), I just want to confirm it will not clash with anything in aca-py the way I am using it.
It doesn't appear to do so, I have used it on my machine withouth issues, but it doesn't hurt to have an educated opinion 🙂 