### PR TITLE
Update aries-cloudagent version to 0.5.2

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -1,3 +1,3 @@
-FROM bcgovimages/aries-cloudagent:py36-1.14-1_0.5.1
+FROM bcgovimages/aries-cloudagent:py36-1.15-0_0.5.2
 
 RUN echo "Pulling aries-cloudagent image from Docker Hub"

--- a/docker/docker-compose.local-debug.yml
+++ b/docker/docker-compose.local-debug.yml
@@ -19,7 +19,7 @@ services:
       - KEYCLOAK_PASSWORD=admin
       - KEYCLOAK_IMPORT=/tmp/master.json
   aca-py:
-    image: bcgovimages/aries-cloudagent:py36-1.14-1_0.5.1
+    image: bcgovimages/aries-cloudagent:py36-1.15-0_0.5.2
     ports:
       - 5678:5678 
       - 5679:5679

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - vc_authn_oidc
 
   aca-py:
-    image: bcgovimages/aries-cloudagent:py36-1.14-1_0.5.1
+    image: bcgovimages/aries-cloudagent:py36-1.15-0_0.5.2
     ports:
       - ${AGENT_ADMIN_PORT}:${AGENT_ADMIN_PORT}
       - ${AGENT_HTTP_PORT}:${AGENT_HTTP_PORT}

--- a/oidc-controller/src/VCAuthn/Utils/PresentationRequestUtils.cs
+++ b/oidc-controller/src/VCAuthn/Utils/PresentationRequestUtils.cs
@@ -47,7 +47,7 @@ namespace VCAuthn.Utils
             {
                 {"proof_request", presentationRequest_1_0}
             };
-            return JsonConvert.SerializeObject(requestBody);
+            return JsonConvert.SerializeObject(requestBody, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
         }
 
         public static List<PresentationAttachment> GeneratePresentationAttachments(this PresentationRequest presentationRequest)


### PR DESCRIPTION
The changes include image version upgrade and tweaks to pass the stricter payolad validation on aca-py