### PR TITLE
Verify proof-request is valid for authentication success

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,7 +65,7 @@ services:
         --inbound-transport http '0.0.0.0' ${AGENT_HTTP_PORT} \
         --outbound-transport http \
         --endpoint ${AGENT_ENDPOINT} \
-        --genesis-url '${LEDGER_URL}/genesis' \
+        --genesis-url '${GENESIS_URL}' \
         --auto-verify-presentation \
         --wallet-type 'indy' \
         --wallet-name 'oidc_agent_wallet' \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -66,6 +66,7 @@ services:
         --outbound-transport http \
         --endpoint ${AGENT_ENDPOINT} \
         --genesis-url '${LEDGER_URL}/genesis' \
+        --auto-verify-presentation \
         --wallet-type 'indy' \
         --wallet-name 'oidc_agent_wallet' \
         --wallet-key '${WALLET_ENCRYPTION_KEY}' \

--- a/docker/manage
+++ b/docker/manage
@@ -178,7 +178,7 @@ configureEnvironment() {
   export AGENT_ENDPOINT=${AGENT_ENDPOINT:-http://$DOCKERHOST:$AGENT_HTTP_PORT}
   export ACAPY_ADMIN_URL="http://aca-py:${AGENT_ADMIN_PORT}"
   export ACAPY_AGENT_URL="${AGENT_ENDPOINT:-http://aca-py:$AGENT_HTTP_PORT}"
-  export LEDGER_URL=${LEDGER_URL-http://$DOCKERHOST:9000}
+  export GENESIS_URL=${GENESIS_URL-http://$DOCKERHOST:9000/genesis}
   export AGENT_SEED="000000000000000000000000Steward1"
   export ACAPY_ADMIN_URL_API_KEY=${ACAPY_ADMIN_URL_API_KEY}
   export ACAPY_ADMIN_MODE="admin-insecure-mode"
@@ -267,7 +267,7 @@ case "${COMMAND}" in
 start|up)
   unset NGROK_AGENT_URL
   unset NGROK_CONTROLLER_URL
-  unset LEDGER_URL
+  unset GENESIS_URL
 
   _startupParams=$(getStartupParams $@)
   configureEnvironment $@
@@ -288,14 +288,14 @@ start-demo)
     isNgrokInstalled
     export NGROK_CONTROLLER_URL=$(${CURL_EXE} http://localhost:4040/api/tunnels | ${JQ_EXE} --raw-output '.tunnels | map(select(.name | contains("vc-authn-controller"))) | .[0] | .public_url')
   fi
-  export LEDGER_URL="http://test.bcovrin.vonx.io"
+  export GENESIS_URL="https://raw.githubusercontent.com/sovrin-foundation/sovrin/stable/sovrin/pool_transactions_sandbox_genesis"
 
   if [ -z "$NGROK_AGENT_URL" ] || [ -z "$NGROK_CONTROLLER_URL" ]; then
     echoError "The NGROK_AGENT_URL or NGROK_CONTROLLER_URL have not been set."
     exit 1
   fi
 
-  echo "Running in demo mode, will use ${LEDGER_URL} as ledger, ${NGROK_AGENT_URL} for the agent and ${NGROK_CONTROLLER_URL} for the controller."
+  echo "Running in demo mode, will use ${GENESIS_URL} to fetch the genesis transaction, ${NGROK_AGENT_URL} for the agent and ${NGROK_CONTROLLER_URL} for the controller."
 
   _startupParams=$(getStartupParams $@)
   configureEnvironment $@

--- a/oidc-controller/src/VCAuthn/ACAPy/ACAPYConstants.cs
+++ b/oidc-controller/src/VCAuthn/ACAPy/ACAPYConstants.cs
@@ -10,7 +10,7 @@ namespace VCAuthn.ACAPY
 
         public const string GetPresentationRecord = "/present-proof/records";
 
-        public const string SuccessfulPresentationUpdate = "presentation_received";
+        public const string VerifiedPresentationState = "verified";
 
         public const string PresentationsTopic = "present_proof";
     }

--- a/oidc-controller/src/VCAuthn/Models/PresentationRequest.cs
+++ b/oidc-controller/src/VCAuthn/Models/PresentationRequest.cs
@@ -46,6 +46,9 @@ namespace VCAuthn.Models
         [JsonProperty("version")]
         public string Version { get; set; }
 
+        [JsonProperty("non_revoked", NullValueHandling = NullValueHandling.Ignore)]
+        public RevocationInterval NonRevoked { get; set; }
+
         [JsonProperty("requested_attributes")]
         public Dictionary<string, RequestedAttribute> RequestedAttributes { get; set; } = new Dictionary<string, RequestedAttribute>();
 

--- a/oidc-controller/src/VCAuthn/Models/RevocationInterval.cs
+++ b/oidc-controller/src/VCAuthn/Models/RevocationInterval.cs
@@ -5,10 +5,10 @@ namespace VCAuthn.Models
     public class RevocationInterval
     {
         [JsonProperty("from")]
-        public uint From { get; set; }
+        public long From { get; set; }
 
         [JsonProperty("to")]
-        public uint To { get; set; }
+        public long To { get; set; }
 
         public override string ToString() =>
             $"{GetType().Name}: " +

--- a/oidc-controller/src/VCAuthn/Utils/PresentationRequestUtils.cs
+++ b/oidc-controller/src/VCAuthn/Utils/PresentationRequestUtils.cs
@@ -12,7 +12,12 @@ namespace VCAuthn.Utils
             PresentationRequest_v_1_0 presentationRequest_1_0 = new PresentationRequest_v_1_0()
             {
                 Version = configuration.Version,
-                Name = configuration.Name
+                Name = configuration.Name,
+                NonRevoked = new RevocationInterval()
+                {
+                    From = 0,
+                    To = new DateTimeOffset(DateTime.Now, TimeSpan.Zero).ToUnixTimeSeconds()
+                }
             };
 
             configuration.RequestedAttributes.ForEach(delegate (RequestedAttribute reqAttribute)

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -16,4 +16,4 @@ The database connection strings set by the following environment variables will 
 
 The `WEBHOOK_URL` environment variable will need to be updated to use the controller's API key. This is achieved by adding `/my-controller-api-key` to the existing value.
 
-Additionally, the agent will need to be registered on the ledger, as it cannot perform this task automatically. To do this, go to the URL that is stored in the `GENESIS_URL` agent environment variable (without the trailing `/genesis`) and register the agent using the seed stored in the agent's wallet secret in OpenShift. 
+Additionally, the agent will need to be registered on the ledger, as it cannot perform this task automatically. To do this, determine which ledger the agent will be connected to (e.g.: by inspecting the `GENESIS_URL` agent environment variable) and register the agent using the seed stored in the agent's wallet secret in OpenShift.


### PR DESCRIPTION
The proof-request was previously considered valid as long as the status was `presentation_received`.

This is incorrect, and the code has been updated to require both the following:
- consider a proof valid if the status is `verified` (requires the agent to be started with `--auto-verify-presentation`)
- consider the proof valid if, after verification, the property `verified: true` is set (this ensures revoked credentials are not accepted)

This fix will cause existing proof-requests that currently succeed even when some attributes are not provided to fail.

@WadeBarnes please wait to merge (I will take care f that) if changes look good as I am syncing the update effort with the devs on A2A (they will need new credentials)