### PR TITLE
Add names array support to requested attribute restrictions

### DIFF
--- a/oidc-controller/src/VCAuthn/ACAPy/ACAPYClient.cs
+++ b/oidc-controller/src/VCAuthn/ACAPy/ACAPYClient.cs
@@ -87,7 +87,7 @@ namespace VCAuthn.ACAPY
             {
                 // Build appropriate json request body
                 string jsonRequestBody = configuration.GeneratePresentationRequest();
-                
+
                 var httpContent = new StringContent(jsonRequestBody, Encoding.UTF8, "application/json");
                 if (!string.IsNullOrEmpty(_adminUrlApiKey))
                 {
@@ -104,12 +104,12 @@ namespace VCAuthn.ACAPY
                     case HttpStatusCode.OK:
                         return JsonConvert.DeserializeObject<CreatePresentationResponse>(responseContent);
                     default:
-                        throw new Exception($"Create presentation request error . Code: {response.StatusCode}");
+                        throw new Exception($"Code: [{response.StatusCode}], Reason: [{responseContent}]");
                 }
             }
             catch (Exception e)
             {
-                throw new Exception("Create presentation request failed .", e);
+                throw new Exception($"Create presentation request failed: {e.Message}", e);
             }
         }
     }

--- a/oidc-controller/src/VCAuthn/IdentityServer/Endpoints/AuthorizationEndpoint/AuthorizeEndpoint.cs
+++ b/oidc-controller/src/VCAuthn/IdentityServer/Endpoints/AuthorizationEndpoint/AuthorizeEndpoint.cs
@@ -141,7 +141,7 @@ namespace VCAuthn.IdentityServer.Endpoints
             catch (Exception e)
             {
                 _logger.LogError(e, "Failed to create presentation request");
-                return VCResponseHelpers.Error(IdentityConstants.AcapyCallFailed, "Failed to create presentation request");
+                return VCResponseHelpers.Error(IdentityConstants.AcapyCallFailed, $"Failed to create presentation request: {e.Message}");
             }
 
 

--- a/oidc-controller/src/VCAuthn/Models/RequestedAttribute.cs
+++ b/oidc-controller/src/VCAuthn/Models/RequestedAttribute.cs
@@ -8,6 +8,9 @@ namespace VCAuthn.Models
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        [JsonProperty("names")]
+        public string[] Names { get; set; }
+
         [JsonProperty("label"), Optional]
         public string Label { get; set; }
 


### PR DESCRIPTION
This addresses #77 

I initially tried to make the `names` array while maintaining backwards-compatibility with existing proof-configurations using `name`, however as far as I could tell this is not trivial and would therefore require either:
- a more significant refactoring of the models backing serialization/deserialization for the proof-configuration (not worth it in my opinion, as it is a one-off handling that doesn't bring too much benefit)
- a breaking change requiring all of the current proof-configurations in use to be updated right away

Leaving both `name` and `names` field seems like a better option since it more accurately reflects what aca-py supports and delegates to the user the responsibility of submitting valid configurations (no special validation was added).

Additionally, the error message resulting from aca-py when generating a proof will now be surfaced in the response to the authentication endpoint (usually a browser window) with details about what caused it (e.g.: during testing I found out that the `names` array requires non-empty attribute restrictions).