### PR TITLE
Align with OOB spec

### DIFF
--- a/oidc-controller/src/VCAuthn/Controllers/PresentationRequestController.cs
+++ b/oidc-controller/src/VCAuthn/Controllers/PresentationRequestController.cs
@@ -70,29 +70,36 @@ namespace VCAuthn.Controllers
                 return NotFound();
             }
 
+            var uri = new UriBuilder(url);
+            var message = HttpUtility.ParseQueryString(uri.Query)["m"];
+            if (string.IsNullOrEmpty(message)) {
+                _logger.LogDebug("Url query param is null or empty");
+                return StatusCode(StatusCodes.Status500InternalServerError);
+            }
+
+            // This is a hack in case URL messages were originally stored unencoded
+            // When URL messages are decoded '+' is converted to a space and must be converted back
+            var formattedMessage = message.Replace(" ", "+");
+            uri.Query = string.Format($"?m={formattedMessage}");
+            var formattedUrl = uri.ToString();
+
             Request.Headers.TryGetValue("Accept", out var accept);
             if (!StringValues.IsNullOrEmpty(accept) && ((ICollection<string>)accept).Contains("application/json"))
             {
-                var uri = new Uri(url);
-                var message = HttpUtility.ParseQueryString(uri.Query)["m"];
-                if (string.IsNullOrEmpty(message)) {
-                    _logger.LogDebug("Url query param is null or empty");
-                    return BadRequest();
-                }
 
-                var jsonMessage = message.FromBase64();
+                var jsonMessage = formattedMessage.FromBase64();
                 if (string.IsNullOrEmpty(jsonMessage)) {
                     _logger.LogDebug("JSON is null or empty");
                     return StatusCode(StatusCodes.Status500InternalServerError);
                 }
 
                 _logger.LogDebug($"Returning JSON");
-                Response.Headers.Add("Location", url);
+                Response.Headers.Add("Location", formattedUrl);
                 return Content(jsonMessage, "application/json; charset=utf-8");
             }
 
-            _logger.LogDebug($"Redirecting to {url}");
-            return Redirect(url);
+            _logger.LogDebug($"Redirecting to {formattedUrl}");
+            return Redirect(formattedUrl);
         }
     }
 }

--- a/oidc-controller/src/VCAuthn/Controllers/PresentationRequestController.cs
+++ b/oidc-controller/src/VCAuthn/Controllers/PresentationRequestController.cs
@@ -1,9 +1,13 @@
 using System;
+using System.Web;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 using VCAuthn.IdentityServer;
 using VCAuthn.Services.Contracts;
+using VCAuthn.Utils;
 
 namespace VCAuthn.Controllers
 {
@@ -64,7 +68,28 @@ namespace VCAuthn.Controllers
                 _logger.LogDebug($"Url is empty. Url key: [{key}]");
                 return NotFound();
             }
-            
+
+            Request.Headers.TryGetValue("Accept", out var accept);
+            if (!StringValues.IsNullOrEmpty(accept) && ((ICollection<string>)accept).Contains("application/json"))
+            {
+                var uri = new Uri(url);
+                var message = HttpUtility.ParseQueryString(uri.Query)["m"];
+                if (string.IsNullOrEmpty(message)) {
+                    _logger.LogDebug("Url query param is null or empty");
+                    return BadRequest();
+                }
+
+                var jsonMessage = message.FromBase64();
+                if (string.IsNullOrEmpty(jsonMessage)) {
+                    _logger.LogDebug("JSON is null or empty");
+                    return BadRequest();
+                }
+
+                _logger.LogDebug($"Returning JSON");
+                Response.Headers.Add("Location", url);
+                return Content(jsonMessage, "application/json; charset=utf-8");
+            }
+
             _logger.LogDebug($"Redirecting to {url}");
             return Redirect(url);
         }

--- a/oidc-controller/src/VCAuthn/Controllers/PresentationRequestController.cs
+++ b/oidc-controller/src/VCAuthn/Controllers/PresentationRequestController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Web;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
@@ -82,7 +83,7 @@ namespace VCAuthn.Controllers
                 var jsonMessage = message.FromBase64();
                 if (string.IsNullOrEmpty(jsonMessage)) {
                     _logger.LogDebug("JSON is null or empty");
-                    return BadRequest();
+                    return StatusCode(StatusCodes.Status500InternalServerError);
                 }
 
                 _logger.LogDebug($"Returning JSON");

--- a/oidc-controller/src/VCAuthn/IdentityServer/Endpoints/AuthorizationEndpoint/AuthorizeEndpoint.cs
+++ b/oidc-controller/src/VCAuthn/IdentityServer/Endpoints/AuthorizationEndpoint/AuthorizeEndpoint.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Net;
+using System.Text;
+using System.Web;
 using System.Threading.Tasks;
 using IdentityModel;
 using IdentityServer4.Configuration;
@@ -151,7 +153,7 @@ namespace VCAuthn.IdentityServer.Endpoints
             string shortUrl;
             try
             {
-                var url = string.Format("{0}?m={1}", _configuration.GetSection("IdentityServer").GetValue<string>("PublicOrigin"), presentationRequest.ToJson().ToBase64());
+                var url = string.Format("{0}?m={1}", _configuration.GetSection("IdentityServer").GetValue<string>("PublicOrigin"), HttpUtility.UrlEncode(presentationRequest.ToJson().ToBase64(), Encoding.UTF8));
                 shortUrl = await _urlShortenerService.CreateShortUrlAsync(url);
             }
             catch (Exception e)

--- a/oidc-controller/src/VCAuthn/IdentityServer/Endpoints/AuthorizationEndpoint/AuthorizeEndpoint.cs
+++ b/oidc-controller/src/VCAuthn/IdentityServer/Endpoints/AuthorizationEndpoint/AuthorizeEndpoint.cs
@@ -153,7 +153,7 @@ namespace VCAuthn.IdentityServer.Endpoints
             string shortUrl;
             try
             {
-                var url = string.Format("{0}?m={1}", _configuration.GetSection("IdentityServer").GetValue<string>("PublicOrigin"), HttpUtility.UrlEncode(presentationRequest.ToJson().ToBase64(), Encoding.UTF8));
+                var url = string.Format("{0}?m={1}", _configuration.GetSection("IdentityServer").GetValue<string>("PublicOrigin"), HttpUtility.UrlEncode(presentationRequest.ToJson().ToBase64Url(), Encoding.UTF8));
                 shortUrl = await _urlShortenerService.CreateShortUrlAsync(url);
             }
             catch (Exception e)

--- a/oidc-controller/src/VCAuthn/Utils/Formatting.cs
+++ b/oidc-controller/src/VCAuthn/Utils/Formatting.cs
@@ -1,3 +1,5 @@
+
+using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
 using System.Text;
 using System;
@@ -21,6 +23,17 @@ namespace VCAuthn.Utils
         {
             byte[] stringBytes = Convert.FromBase64String(value);
             return Encoding.UTF8.GetString(stringBytes);
+        }
+
+        public static string ToBase64Url(this string value)
+        {
+            return Base64UrlEncoder.Encode(value);
+        }
+
+        public static string FromBase64Url(this string value)
+        {
+            return Base64UrlEncoder.Decode(value);
+
         }
     }
 }


### PR DESCRIPTION
This PR introduces changes that align with the OOB specification and further enables support for connection-less presentation requests in mobile wallet implementations.

* OOB messages are base64 URL encoded as opposed to base64 encoded. This resolves issues with introducing special characters such as `+` in the encoded string which can carry meaning in a URL.
* Provides a mechanism to return decoded OOB messages in JSON format from the URL shortening service while still supporting redirect operations.

References:
1. https://datatracker.ietf.org/doc/html/rfc4648#section-5
2. https://github.com/hyperledger/aries-rfcs/tree/main/features/0434-outofband#url-shortening