### PR TITLE
Fix issues with loading Vue.

### DIFF
--- a/oidc-controller/src/VCAuthn/Views/Authorize/Authorize.cshtml
+++ b/oidc-controller/src/VCAuthn/Views/Authorize/Authorize.cshtml
@@ -14,7 +14,7 @@
     <link
       type="text/css"
       rel="stylesheet"
-      href="//unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.min.css"
+      href="//unpkg.com/bootstrap-vue@2.21.2/dist/bootstrap-vue.min.css"
     />
 
     <!-- Load polyfills to support older browsers -->
@@ -24,11 +24,11 @@
     ></script>
 
     <!-- Load Vue followed by BootstrapVue -->
-    <script src="//unpkg.com/vue@latest/dist/vue.min.js"></script>
-    <script src="//unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.min.js"></script>
+    <script src="//unpkg.com/vue@2.6.14/dist/vue.min.js"></script>
+    <script src="//unpkg.com/bootstrap-vue@2.21.2/dist/bootstrap-vue.min.js"></script>
 
     <!-- Load the following for BootstrapVueIcons support -->
-    <script src="//unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue-icons.min.js"></script>
+    <script src="//unpkg.com/bootstrap-vue@2.21.2/dist/bootstrap-vue-icons.min.js"></script>
 
     <!-- qrcode.vue -->
     <script src="//unpkg.com/qrcode.vue@1.7.0/dist/qrcode.vue.js"></script>


### PR DESCRIPTION
- A new version of Vue was released which changes the file package naming.
- Pin the version of Vue to a version known to work for our app until we have time to upgrade to Vue 3.
- This is a break fix.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>