### PR TITLE
2.0: Move presentation claims out of top level of idtoken. 

### DIFF
--- a/docker/keycloak/config/keycloak_import.json
+++ b/docker/keycloak/config/keycloak_import.json
@@ -1110,13 +1110,13 @@
     },
     {
       "id": "f4893fe6-da75-4cb5-bced-0500991988bf",
-      "name": "vc_proof_claims",
+      "name": "vc_presented_attributes",
       "identityProviderAlias": "vc-authn",
       "identityProviderMapper": "oidc-user-attribute-idp-mapper",
       "config": {
         "syncMode": "inherit",
-        "claim": "vc_proof_claims",
-        "user.attribute": "vc_proof_claims"
+        "claim": "vc_presented_attributes",
+        "user.attribute": "vc_presented_attributes"
       }
     }
   ],

--- a/docker/keycloak/config/keycloak_import.json
+++ b/docker/keycloak/config/keycloak_import.json
@@ -1107,6 +1107,17 @@
         "claim": "pres_req_conf_id",
         "user.attribute": "pres_req_conf_id"
       }
+    },
+    {
+      "id": "f4893fe6-da75-4cb5-bced-0500991988bf",
+      "name": "vc_proof_claims",
+      "identityProviderAlias": "vc-authn",
+      "identityProviderMapper": "oidc-user-attribute-idp-mapper",
+      "config": {
+        "syncMode": "inherit",
+        "claim": "vc_proof_claims",
+        "user.attribute": "vc_proof_claims"
+      }
     }
   ],
   "components": {

--- a/docker/manage
+++ b/docker/manage
@@ -207,20 +207,20 @@ configureEnvironment() {
   fi
 
   # Multi-Tenant ACA-Py config
-  # export ACAPY_HOST="http://tenant-proxy"
-  # export ACAPY_TENANCY="multi"
-  # export MT_ACAPY_WALLET_ID="ece83a72-81df-40b0-b770-9a55d92b254d"
-  # export ACAPY_NGROK_TUNNEL_HOST="http://ngrok-traction-agent:4040"
-  # export AGENT_ADMIN_PORT="8080"
+  export ACAPY_HOST="http://tenant-proxy"
+  export ACAPY_TENANCY="multi"
+  export MT_ACAPY_WALLET_ID="ece83a72-81df-40b0-b770-9a55d92b254d"
+  export ACAPY_NGROK_TUNNEL_HOST="http://ngrok-traction-agent:4040"
+  export AGENT_ADMIN_PORT="8080"
 
 
-  # # Single-Tenant ACA-Py config
-  export ACAPY_HOST="http://aca-py"
-  export ACAPY_TENANCY="single"
-  export ST_ACAPY_ADMIN_API_KEY_NAME="x-api-key"
-  export ST_ACAPY_ADMIN_API_KEY="change-me"
-  export ACAPY_NGROK_TUNNEL_HOST="http://aca-py-ngrok:4040"
-  export AGENT_ADMIN_PORT="8077"
+  # # # Single-Tenant ACA-Py config
+  # export ACAPY_HOST="http://aca-py"
+  # export ACAPY_TENANCY="single"
+  # export ST_ACAPY_ADMIN_API_KEY_NAME="x-api-key"
+  # export ST_ACAPY_ADMIN_API_KEY="change-me"
+  # export ACAPY_NGROK_TUNNEL_HOST="http://aca-py-ngrok:4040"
+  # export AGENT_ADMIN_PORT="8077"
 
   # ACA-py url constructions
   export AGENT_HTTP_PORT="8030"

--- a/docs/ConfigurationGuide.md
+++ b/docs/ConfigurationGuide.md
@@ -37,7 +37,7 @@ To configure VC Authn you will need access to its database, either through a ter
 
 The following steps are applicable whether your client is an AIM broker or a web  trying to authenticate directly.
 
-There are several tables that need to be updated when configuring a new client. For exhaustive documentation please refer to the [IdentityServer4 docs](https://identityserver4.readthedocs.io/en/latest), the following is a list of commonly used settings:
+There are several tables that need to be updated when configuring a new client, the following is a list of commonly used settings:
 
 - **Clients**: this table holds the main list of clients that are authorized to authenticate using VC Authn. Add your client, making sure to use your unique **Client ID** name when doing so:
 

--- a/oidc-controller/api/core/logger_util.py
+++ b/oidc-controller/api/core/logger_util.py
@@ -1,0 +1,21 @@
+import logging
+import time
+
+
+from typing import Callable, Any
+
+
+def debug_info(func: Callable[..., Any]) -> Callable[..., Any]:
+    def wrapper(*args, **kwargs):
+        logger = logging.getLogger(func.__name__)
+        logger.setLevel(logging.DEBUG)
+        logger.info(f" >>>> {func.__name__}")
+        logger.debug(f" ..with params={{{args}}}")
+        start_time = time.time()
+        ret_val = func(*args, **kwargs)
+        end_time = time.time()
+        logger.info(f" <<<< {func.__name__} and took {end_time-start_time:.3f} seconds")
+        logger.debug(f" ..with ret_val={{{ret_val}}}")
+        return ret_val
+
+    return wrapper

--- a/oidc-controller/api/core/oidc/issue_token_service.py
+++ b/oidc-controller/api/core/oidc/issue_token_service.py
@@ -5,11 +5,14 @@ import dataclasses
 from datetime import datetime
 from typing import List, Dict, Any
 from pydantic import BaseModel
-
+from oic.oic.message import OpenIDSchema
 from ...authSessions.models import AuthSession
 from ...verificationConfigs.models import VerificationConfig
+from ...core.logger_util import debug_info
 
 logger = logging.getLogger(__name__)
+
+PROOF_CLAIMS_ATTRIBUTE_NAME = "vc_presented_attributes"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -26,13 +29,11 @@ class Token(BaseModel):
     claims: Dict[str, Any]
 
     @classmethod
+    @debug_info
     def get_claims(
         cls, pres_exch: Dict, auth_session: AuthSession, ver_config: VerificationConfig
     ) -> List["Claim"]:
         """Converts vc presentation values to oidc claims"""
-        logger.debug(f">>> Token.get_claims")
-        logger.info(pres_exch)
-
         oidc_claims: List[Claim] = [
             Claim(
                 type="pres_req_conf_id",
@@ -46,7 +47,9 @@ class Token(BaseModel):
             Claim(type="nonce", value=auth_session.request_parameters["nonce"])
         )
 
-        presentation_claims: Dict[str, Claim] = {}
+        presentation_claims: Dict[str, Claim] = {
+            "given_name": Claim("email", "email1@net.com")
+        }
         logger.info(
             auth_session.presentation_exchange["presentation_request"][
                 "requested_attributes"
@@ -78,10 +81,9 @@ class Token(BaseModel):
 
         # add sub and append presentation_claims
         oidc_claims.append(Claim(type="sub", value=sub_id_value))
-        presentation_claims.values()
 
         result = {c.type: c.value for c in oidc_claims}
-        result["vc_proof_claims"] = json.dumps(
+        result[PROOF_CLAIMS_ATTRIBUTE_NAME] = json.dumps(
             {c.type: c.value for c in presentation_claims.values()}
         )
         return result
@@ -89,7 +91,7 @@ class Token(BaseModel):
     # renames and calculates dict members appropriate to https://openid.net/specs/openid-connect-core-1_0.html#IDToken
     # and
     # https://github.com/OpenIDC/pyoidc/blob/26ea5121239dad03c5c5551cca149cb984df1ec9/src/oic/oic/message.py#L720
-
+    @debug_info
     def idtoken_dict(self, nonce: str) -> Dict:
         """Converts oidc claims to IdToken attribute names"""
 
@@ -103,6 +105,24 @@ class Token(BaseModel):
         result["nonce"] = nonce
 
         result.update(self.claims)
-        logger.info(f"<<< idtoken_dict r={result}")
+
+        # identify if any standardclaims were provided in the proof and return them at the top level.
+        # https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+        # make copy of dict
+        r2 = result.copy()
+        # add nested values to top level
+        r2.update(json.loads(self.claims[PROOF_CLAIMS_ATTRIBUTE_NAME]))
+        # only keep ones that match the OpenIDschema
+        r2 = {
+            key: r2[key]
+            for key in set(r2.keys()).intersection(set(OpenIDSchema().c_param.keys()))
+        }
+
+        # verify with library schema
+        standard_claims = OpenIDSchema().from_dict(r2)
+        standard_claims.verify()
+        # add to the top level of the dict.
+        for key, value in standard_claims.to_dict().items():
+            result[key] = value
 
         return result

--- a/oidc-controller/api/core/oidc/issue_token_service.py
+++ b/oidc-controller/api/core/oidc/issue_token_service.py
@@ -47,9 +47,7 @@ class Token(BaseModel):
             Claim(type="nonce", value=auth_session.request_parameters["nonce"])
         )
 
-        presentation_claims: Dict[str, Claim] = {
-            "given_name": Claim("email", "email1@net.com")
-        }
+        presentation_claims: Dict[str, Claim] = {}
         logger.info(
             auth_session.presentation_exchange["presentation_request"][
                 "requested_attributes"


### PR DESCRIPTION
Breaking Change: 

All existing oidc configurations will need to be update to look for any imported attributes from the presentation under the `vc_proof_claims` member of the idtoken. 

Thoughts on the attribute name of `vc_proof_claims`. 

