### PR TITLE
Local DID instead of Public DID.

### DIFF
--- a/oidc-controller/api/core/acapy/client.py
+++ b/oidc-controller/api/core/acapy/client.py
@@ -2,14 +2,15 @@ import requests
 import json
 import logging
 from uuid import UUID
-from .models import WalletPublicDid, CreatePresentationResponse
+from .models import WalletDid, CreatePresentationResponse
 from ..config import settings
 from .config import AgentConfig, MultiTenantAcapy, SingleTenantAcapy
 
 _client = None
 logger = logging.getLogger(__name__)
 
-WALLET_DID_URI = "/wallet/did/public"
+WALLET_DID_URI = "/wallet/did"
+PUBLIC_WALLET_DID_URI = "/wallet/did/public"
 CREATE_PRESENTATION_REQUEST_URL = "/present-proof/create-request"
 PRESENT_PROOF_RECORDS = "/present-proof/records"
 
@@ -85,18 +86,28 @@ class AcapyClient:
         logger.debug(f"<<< verify_presentation -> {resp}")
         return resp
 
-    def get_wallet_public_did(self) -> WalletPublicDid:
-        logger.debug(f">>> get_wallet_public_did")
+    def get_wallet_did(self, public=False) -> WalletDid:
+        logger.debug(f">>> get_wallet_did")
+        url = None
+        if public:
+            url = self.acapy_host + PUBLIC_WALLET_DID_URI
+        else:
+            url = self.acapy_host + WALLET_DID_URI
 
         resp_raw = requests.get(
-            self.acapy_host + WALLET_DID_URI,
+            url,
             headers=self.agent_config.get_headers(),
         )
         assert (
             resp_raw.status_code == 200
         ), f"{resp_raw.status_code}::{resp_raw.content}"
         resp = json.loads(resp_raw.content)
-        public_did = WalletPublicDid.parse_obj(resp["result"])
 
-        logger.debug(f"<<< get_wallet_public_did -> {public_did}")
-        return public_did
+        if public:
+            resp_payload = resp["result"]
+        else:
+            resp_payload = resp["results"][0]
+        did = WalletDid.parse_obj(resp_payload)
+
+        logger.debug(f"<<< get_wallet_did -> {did}")
+        return did

--- a/oidc-controller/api/core/acapy/models.py
+++ b/oidc-controller/api/core/acapy/models.py
@@ -3,13 +3,13 @@ from typing import Optional, Dict
 from pydantic import BaseModel, Field
 
 
-class WalletPublicDid(BaseModel):
+class WalletDid(BaseModel):
     did: str
     verkey: str
     posture: str
 
 class WalletDidPublicResponse(BaseModel):
-    result: Optional[WalletPublicDid]
+    result: Optional[WalletDid]
 
 
 class CreatePresentationResponse(BaseModel):

--- a/oidc-controller/api/core/aries/__init__.py
+++ b/oidc-controller/api/core/aries/__init__.py
@@ -1,5 +1,5 @@
 from .present_proof_attachment import PresentProofv10Attachment
-from .service_decorator import ServiceDecorator
+from .service_decorator import ServiceDecorator, OOBServiceDecorator
 
 from .present_proof_presentation import PresentationRequestMessage
 from .out_of_band import OutOfBandMessage, OutOfBandPresentProofAttachment

--- a/oidc-controller/api/core/aries/out_of_band.py
+++ b/oidc-controller/api/core/aries/out_of_band.py
@@ -1,5 +1,6 @@
 from typing import Dict, List
 from pydantic import BaseModel, Field
+from .service_decorator import OOBServiceDecorator
 
 
 class OutOfBandPresentProofAttachment(BaseModel):
@@ -25,7 +26,7 @@ class OutOfBandMessage(BaseModel):
     request_attachments: List[OutOfBandPresentProofAttachment] = Field(
         alias="requests~attach"
     )
-    services: List[str] = Field(alias="services")
+    services: List[OOBServiceDecorator] = Field(alias="services")
 
     class Config:
         allow_population_by_field_name = True

--- a/oidc-controller/api/core/aries/service_decorator.py
+++ b/oidc-controller/api/core/aries/service_decorator.py
@@ -10,3 +10,16 @@ class ServiceDecorator(BaseModel):
 
     class Config:
         allow_population_by_field_name = True
+
+
+class OOBServiceDecorator(ServiceDecorator):
+    # ServiceDecorator
+    recipient_keys: Optional[List[str]]
+    routing_keys: Optional[List[str]] = Field(default=[])
+    service_endpoint: Optional[str]
+    id: str = Field(default="did:vc-authn-oidc:123456789zyxwvutsr#did-communication")
+    type: str = Field(default="did-communication")
+    priority: int = 0
+
+    class Config:
+        allow_population_by_field_name = True

--- a/oidc-controller/api/routers/presentation_request.py
+++ b/oidc-controller/api/routers/presentation_request.py
@@ -64,5 +64,5 @@ async def send_connectionless_proof_req(
             service=s_d,
         )
         msg_contents = msg
-    print(msg_contents)
+    print(msg_contents.dict(by_alias=True))
     return JSONResponse(msg_contents.dict(by_alias=True))

--- a/oidc-controller/api/routers/presentation_request.py
+++ b/oidc-controller/api/routers/presentation_request.py
@@ -13,6 +13,7 @@ from ..core.aries import (
     ServiceDecorator,
     OutOfBandMessage,
     OutOfBandPresentProofAttachment,
+    OOBServiceDecorator,
 )
 from ..core.config import settings
 
@@ -30,7 +31,7 @@ async def send_connectionless_proof_req(
     auth_session: AuthSession = await AuthSessionCRUD.get_by_pres_exch_id(pres_exch_id)
     client = AcapyClient()
 
-    public_did = client.get_wallet_public_did()
+    wallet_did = client.get_wallet_did()
 
     byo_attachment = PresentProofv10Attachment.build(
         auth_session.presentation_exchange["presentation_request"]
@@ -38,10 +39,12 @@ async def send_connectionless_proof_req(
 
     msg = None
     if settings.USE_OOB_PRESENT_PROOF:
+        oob_s_d = OOBServiceDecorator(
+            service_endpoint=client.service_endpoint, recipient_keys=[wallet_did.verkey]
+        )
         msg = PresentationRequestMessage(
             id=auth_session.presentation_exchange["thread_id"],
             request=[byo_attachment],
-            # service=s_d,
         )
         oob_msg = OutOfBandMessage(
             request_attachments=[
@@ -51,12 +54,12 @@ async def send_connectionless_proof_req(
                 )
             ],
             id=auth_session.presentation_exchange["thread_id"],
-            services=["did:sov:" + public_did.did],
+            services=[oob_s_d.dict()],
         )
         msg_contents = oob_msg
     else:
         s_d = ServiceDecorator(
-            service_endpoint=client.service_endpoint, recipient_keys=[public_did.verkey]
+            service_endpoint=client.service_endpoint, recipient_keys=[wallet_did.verkey]
         )
         msg = PresentationRequestMessage(
             id=auth_session.presentation_exchange["thread_id"],


### PR DESCRIPTION
You can use a local did as long as you use a fully qualified `service`.

The second one (OOB with a DIDCOMM service), ACA-py accepts the invitation just fine, but the BC Wallet App does not, This PR will stay in draft until the BC Wallet team confirms that is a bug on their end and has a plan to resolve it. It's possibly a missing feature in AFJ (Aries Framework Javascript). 

For 'connectionless present-proof request' that means this https://github.com/hyperledger/aries-rfcs/tree/main/features/0056-service-decorator.

but For a 'out-of-band invitation with present-proof request' that means this. https://github.com/hyperledger/aries-rfcs/tree/main/features/0067-didcomm-diddoc-conventions#service-conventions.

