### PR TITLE
Publish image to GHCR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ on:
         type: string
 
 env:
-  PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64,linux/386' }}
+  PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
 
 jobs:
   publish-image:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
           images: |
             ghcr.io/${{ steps.info.outputs.repo-owner }}/vc-authn-oidc
           tags: |
-            type=raw,value=py${{ matrix.python-version }}-${{ inputs.tag || github.event.release.tag_name }}
+            type=raw,value=${{ inputs.tag || github.event.release.tag_name }}
 
       - name: Build and Push Image to ghcr.io
         uses: docker/build-push-action@v3
@@ -77,8 +77,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           target: main
-          build-args: |
-            python_version=${{ matrix.python-version }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           platforms: ${{ env.PLATFORMS }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,8 +27,6 @@ jobs:
   publish-image:
     strategy:
       fail-fast: false
-      matrix:
-        python-version: ['3.11']
 
     name: Publish VC-AuthN Image
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,94 @@
+name: Publish VC-AuthN Image
+run-name: Publish VC-AuthN ${{ inputs.tag || github.event.release.tag_name }} Image
+on:
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag'
+        required: true
+        type: string
+      platforms:
+        description: 'Platforms - Comma separated list of the platforms to support.'
+        required: true
+        default: linux/amd64
+        type: string
+      ref:
+        description: 'Optional - The branch, tag or SHA to checkout.'
+        required: false
+        type: string
+
+env:
+  PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64,linux/386' }}
+
+jobs:
+  publish-image:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11']
+
+    name: Publish VC-AuthN Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref || '' }}
+
+      - name: Gather image info
+        id: info
+        run: |
+          echo "repo-owner=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_OUTPUT
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Image Metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ steps.info.outputs.repo-owner }}/vc-authn-oidc
+          tags: |
+            type=raw,value=py${{ matrix.python-version }}-${{ inputs.tag || github.event.release.tag_name }}
+
+      - name: Build and Push Image to ghcr.io
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          context: .
+          file: docker/oidc-controller/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: main
+          build-args: |
+            python_version=${{ matrix.python-version }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          platforms: ${{ env.PLATFORMS }}
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/docker/oidc-controller/Dockerfile
+++ b/docker/oidc-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.11 as main
 
 WORKDIR /app
 


### PR DESCRIPTION
Build and push image to GHCR upon creation of a new release.

Target architectures are `linux/amd64` and `linux/arm64`: for some reason, build fails for `linux/386` when pulling `anyio` - will have to look at it in the future if we need `linux/386` images published.