### PR TITLE
Revert image-tag handling changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,13 +40,6 @@ jobs:
         id: info
         run: |
           echo "repo-owner=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_OUTPUT
-      
-      # Store the version, stripping any v-prefix
-      - name: Compile image tag version
-        run: |
-          IMAGE_TAG=${github.event.release.tag_name#v}
-          echo Image tag: $IMAGE_TAG
-          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
 
       - name: Cache Docker layers
         uses: actions/cache@v3
@@ -73,7 +66,7 @@ jobs:
           images: |
             ghcr.io/${{ steps.info.outputs.repo-owner }}/vc-authn-oidc
           tags: |
-            type=raw,value=${{ inputs.tag || IMAGE_TAG }}
+            type=raw,value=${{ inputs.tag || github.event.release.tag_name }}
 
       - name: Build and Push Image to ghcr.io
         uses: docker/build-push-action@v3


### PR DESCRIPTION
The intent was to strip the `v` prefix from tagged versions, but it is becoming more cumbersome than expected: tags will just be names *without* prefixing them with `v`