### PR TITLE
Feature/release action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=pr
             type=sha
 
       - name: Build and Push Image to ghcr.io

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,93 @@
+name: Publish VC-AuthN Image
+run-name: Publish VC-AuthN ${{ inputs.tag || github.event.release.tag_name }} Image
+on:
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag"
+        required: true
+        type: string
+      platforms:
+        description: "Platforms - Comma separated list of the platforms to support."
+        required: true
+        default: linux/amd64
+        type: string
+      ref:
+        description: "Optional - The branch, tag or SHA to checkout."
+        required: false
+        type: string
+
+env:
+  PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
+
+jobs:
+  publish-image:
+    if: github.repository_owner == 'bcgov'
+    strategy:
+      fail-fast: false
+
+    name: Publish VC-AuthN Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref || '' }}
+
+      - name: Gather image info
+        id: info
+        run: |
+          echo "repo-owner=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_OUTPUT
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Image Metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ steps.info.outputs.repo-owner }}/vc-authn-oidc
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Build and Push Image to ghcr.io
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          context: .
+          file: docker/oidc-controller/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: main
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          platforms: ${{ env.PLATFORMS }}
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
Adding the GitHub Actions workflow definition for publishing the `vc-authn-oidc` Docker image on release creation to the `main` branch. Only the `2.0-development` branch currently has the workflow definition currently and I suspect this might be causing issues when trying to run the action (i.e.: the `docker/metadata-action@v4` step is not correctly dealing with the semver naming of the tag, causing tags to include the `v` prefix). It does make sense either way to have the action in the main branch already, as we will be releasing the `1.0.0` image before switching to the newer version, for tracking/historical reasons.

The commit was cherry-picked from `2.0-development` so there should not be issues, and the re-introduction of the extra metadata is a descendant commit. I will pull this change back into `2.0-development` as soon as it is merged into `main` (by cherry-picking the other way around).