### PR TITLE
Re-introduce pr ref for tagging Docker image on release action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=pr
             type=sha
 
       - name: Build and Push Image to ghcr.io


### PR DESCRIPTION
This *should* sync-up the workflow file with what is in `main`