### PR TITLE
Websocket 305 - Fixing websocket with https.

### DIFF
--- a/oidc-controller/api/templates/verified_credentials.html
+++ b/oidc-controller/api/templates/verified_credentials.html
@@ -265,7 +265,7 @@
     /**
      * Initialize the Websocket
      */
-    const socket = io("ws://" + location.host, {
+    const socket = io(location.host, {
       path: "/ws/socket.io",
       autoConnect: false,
     });


### PR DESCRIPTION
A small update to the websocket URL.

Previously the websocket only worked in development environments (http). This will hopefully allow traffic over https as well.