### PR TITLE
Update to docker-compose to get redirect URI to work

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -65,6 +65,10 @@ services:
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_PASSWORD}
       # KEYCLOAK_LOGLEVEL: ${KEYCLOAK_LOGLEVEL}
       # ROOT_LOGLEVEL: ${KEYCLOAK_ROOT_LOGLEVEL}
+      #
+      # The following parameter addresses a redirect error on logout in later (post KC 16 at least).
+      # It may be fixable by updating the vue app as well -- google "keycloak error Invalid parameter: redirect_uri"
+      KC_SPI_LOGIN_PROTOCOL_OPENID_CONNECT_LEGACY_LOGOUT_REDIRECT_URI: true
     depends_on:
       - keycloak-db
     networks:


### PR DESCRIPTION
Adds a magic Keycloak parameter to fix a redirect error on logout we are seeing following the upgrade to Keycloak 22. As noted, there may be a fix in the app itself, perhaps by updating the "keycloak.js" file, or some other app specific config.  However, this seems to work.

This does not change anything with the OpenShift/Helm Chart configuration, so more may be needed in that areain the future. For now I think, this is enough.

Fixes #310.
