### PR TITLE
[Hotfix] Add missing dependency chart repo to fix chart releaser 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,6 +107,10 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v3
+      
+      - name: Add dependency chart repos
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami  
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0


### PR DESCRIPTION
`vc-authn-oidc` chart has dependency on `bitnami` helm chart repo. This must be added before Chart Releaser can work.