### PR TITLE
Deprecate name in favour of names array in requested_attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ curl -X 'POST' \
     "requested_attributes": [
 
       {
-        "name": "email",
+        "names": ["email"],
         "restrictions": [
           {
             "schema_name": "verified-email",

--- a/oidc-controller/api/verificationConfigs/examples.py
+++ b/oidc-controller/api/verificationConfigs/examples.py
@@ -5,8 +5,7 @@ ex_ver_config_read = {
         "name": "Basic Proof",
         "version": "1.0",
         "requested_attributes": [
-            {"name": "first_name", "restrictions": []},
-            {"name": "last_name", "restrictions": []},
+            {"names": ["first_name", "last_name"], "restrictions": []},
         ],
         "requested_predicates": [],
     },
@@ -19,8 +18,7 @@ ex_ver_config_create = {
         "name": "Basic Proof",
         "version": "1.0",
         "requested_attributes": [
-            {"name": "first_name", "restrictions": []},
-            {"name": "last_name", "restrictions": []},
+            {"names": ["first_name", "last_name"], "restrictions": []},
         ],
         "requested_predicates": [],
     },

--- a/oidc-controller/api/verificationConfigs/models.py
+++ b/oidc-controller/api/verificationConfigs/models.py
@@ -17,8 +17,7 @@ class AttributeFilter(BaseModel):
 
 
 class ReqAttr(BaseModel):
-    name: str
-    names: Optional[List[str]]
+    names: List[str]
     label: Optional[str]
     restrictions: List[AttributeFilter]
 

--- a/oidc-controller/api/verificationConfigs/tests/test_vc_crud.py
+++ b/oidc-controller/api/verificationConfigs/tests/test_vc_crud.py
@@ -102,7 +102,7 @@ async def test_ver_config_patch_proof_request(db_client: Callable[[], MongoClien
         VerificationConfigPatch(
             proof_request=VerificationProofRequest(
                 version="0.0.2",
-                requested_attributes=[ReqAttr(name="first_name", restrictions=[])],
+                requested_attributes=[ReqAttr(names=["first_name"], restrictions=[])],
                 requested_predicates=[],
             ),
         ),
@@ -113,4 +113,5 @@ async def test_ver_config_patch_proof_request(db_client: Callable[[], MongoClien
         {"ver_config_id": "test_ver_config"}
     )
     assert document["proof_request"]["version"] == "0.0.2"
-    assert document["proof_request"]["requested_attributes"][0]["name"] == "first_name"
+    assert len(document["proof_request"]["requested_attributes"][0]["names"]) == 1
+    assert document["proof_request"]["requested_attributes"][0]["names"][0] == "first_name"


### PR DESCRIPTION
The `names` array is more flexible as it allows proofs to define one or more attributes to be requested from the same credential.
Instead of trying to handle exclusiveness between `name` and `names`, this change deprecates the single-attribute restriction in favour of the array that can, if needed, be used with one element definition only.