### PR TITLE
Fix/names array mappings

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
       #
       # The following parameter addresses a redirect error on logout in later (post KC 16 at least).
       # It may be fixable by updating the vue app as well -- google "keycloak error Invalid parameter: redirect_uri"
-      KC_SPI_LOGIN_PROTOCOL_OPENID_CONNECT_LEGACY_LOGOUT_REDIRECT_URI: true
+      KC_SPI_LOGIN_PROTOCOL_OPENID_CONNECT_LEGACY_LOGOUT_REDIRECT_URI: "true"
     depends_on:
       - keycloak-db
     networks:
@@ -98,7 +98,7 @@ services:
       - ACAPY_WALLET_STORAGE_TYPE=${WALLET_TYPE}
       - ACAPY_READ_ONLY_LEDGER=true
       - ACAPY_GENESIS_TRANSACTIONS_LIST=/tmp/ledgers.yaml
-      - ACAPY_LOG_LEVEL=debug
+      - ACAPY_LOG_LEVEL=info
       - ACAPY_WEBHOOK_URL=${CONTROLLER_WEB_HOOK_URL}
       - ACAPY_AUTO_PROVISION=true
       - POSTGRESQL_WALLET_HOST=${POSTGRESQL_WALLET_HOST}

--- a/oidc-controller/api/core/acapy/client.py
+++ b/oidc-controller/api/core/acapy/client.py
@@ -1,11 +1,13 @@
-import requests
 import json
-import structlog
 from typing import Optional, Union
 from uuid import UUID
-from .models import WalletDid, CreatePresentationResponse
+
+import requests
+import structlog
+
 from ..config import settings
 from .config import AgentConfig, MultiTenantAcapy, SingleTenantAcapy
+from .models import CreatePresentationResponse, WalletDid
 
 _client = None
 logger = structlog.getLogger(__name__)
@@ -67,7 +69,7 @@ class AcapyClient:
         assert resp_raw.status_code == 200, resp_raw.content
         resp = json.loads(resp_raw.content)
 
-        logger.debug("<<< get_presentation_request -> {resp}")
+        logger.debug(f"<<< get_presentation_request -> {resp}")
         return resp
 
     def verify_presentation(self, presentation_exchange_id: Union[UUID, str]):

--- a/oidc-controller/api/core/models.py
+++ b/oidc-controller/api/core/models.py
@@ -45,3 +45,8 @@ class TimestampModel(BaseModel):
 
 class GenericErrorMessage(BaseModel):
     detail: str
+
+
+class RevealedAttribute(BaseModel):
+    sub_proof_index: int
+    values: dict

--- a/oidc-controller/api/core/oidc/issue_token_service.py
+++ b/oidc-controller/api/core/oidc/issue_token_service.py
@@ -149,5 +149,3 @@ class Token(BaseModel):
             result[key] = value
 
         return result
-
-        return result

--- a/oidc-controller/api/routers/oidc.py
+++ b/oidc-controller/api/routers/oidc.py
@@ -171,4 +171,5 @@ async def post_token(request: Request, db: Database = Depends(get_db)):
     token_response = provider.provider.handle_token_request(
         data, request.headers, claims
     )
+    logger.debug(f"Token response: {token_response.to_dict()}")
     return token_response.to_dict()


### PR DESCRIPTION
The mapping needed to extract the result of a proof when using restrictions declared with the `names` array is different than with the regular `name` restriction. Somehow unit tests pass and didn't flag this problem.

This is meant to get the service up-and-running again, with some basic exception logging: the logged statement is still vague (i.e.: when artificially breaking the access path to the data structure property it will log something like `vc-authn-controller-1     | {"event": "An exception occurred while extracting the proof claims: 'raw'", "logger": "api.core.oidc.issue_token_service", "level": "error", "timestamp": "2023-09-14T16:23:45.776184Z"}`), but at least points to the right spot in the code.

Additionally, basic type-hinting was added where possible to help limit this type of issue in the future.

Resolves #331 