### PR TITLE
Add debugger functionality to vc-authn controller container

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,29 @@ curl -X 'POST' \
 - Lastly, obtain a valid BCGov Verified Email credential from the [BCGov Email Verification Service](https://email-verification.vonx.io)
 
 After all these steps have been completed, you should be able to authenticate with the demo application using the "Verified Credential Access" option.
+
+## Debugging
+
+To connect a debugger to the `vc-authn` controller service, start the project using `DEBUGGER=true ./manage start` and then launch the debugger, it should connect automatically to the container.
+
+This is a sample debugger launch configuration for VSCode that can be used by adding it to `launch.json`:
+```json
+{
+    "version": "0.1.0",
+    "configurations": [
+        {
+            "name": "Python: Debug VC-AuthN Controller",
+            "type": "python",
+            "request": "attach",
+            "port": 5678,
+            "host": "localhost",
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}/oidc-controller",
+                    "remoteRoot": "/app"
+                }
+            ]
+        }
+    ]
+}
+```

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     command:
       [
         "-c",
-        "uvicorn api.main:app --reload --host 0.0.0.0 --port 5000 --log-level info",
+        "pip install debugpy -t /tmp && python /tmp/debugpy --wait-for-client --listen 0.0.0.0:5678 -m uvicorn api.main:app --reload --host 0.0.0.0 --port 5000",
       ]
     environment:
       - DB_HOST=${MONGODB_HOST}
@@ -28,6 +28,7 @@ services:
       - USE_OOB_PRESENT_PROOF=${USE_OOB_PRESENT_PROOF}
     ports:
       - ${CONTROLLER_SERVICE_PORT}:5000
+      - 5678:5678
     volumes:
       - ../oidc-controller:/app:rw
     networks:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -2,14 +2,19 @@ version: "3"
 services:
   controller:
     image: vc-authn-oidc-controller
-
     entrypoint: /bin/bash
-    command:
-      [
-        "-c",
-        "pip install debugpy -t /tmp && python /tmp/debugpy --wait-for-client --listen 0.0.0.0:5678 -m uvicorn api.main:app --reload --host 0.0.0.0 --port 5000",
-      ]
+    command: >
+      -c "
+      if [ $DEBUGGER ] && [ "$DEBUGGER" == "true" ]; then
+        echo 'Starting in debug mode...'
+        pip install debugpy -t /tmp && \
+        python /tmp/debugpy --wait-for-client --listen 0.0.0.0:5678 -m uvicorn api.main:app --reload --host 0.0.0.0 --port 5000;
+      else
+        echo 'Starting in production mode...'
+        uvicorn api.main:app --reload --host 0.0.0.0 --port 5000;
+      fi"
     environment:
+      - DEBUGGER=${DEBUGGER}
       - DB_HOST=${MONGODB_HOST}
       - DB_PORT=${MONGODB_PORT}
       - DB_NAME=${MONGODB_NAME}

--- a/oidc-controller/api/core/config.py
+++ b/oidc-controller/api/core/config.py
@@ -1,17 +1,15 @@
 import json
 import logging
-import sys
 import logging.config
-import structlog
 import os
+import sys
 from enum import Enum
 from functools import lru_cache
+from pathlib import Path
 from typing import Optional, Union
 
+import structlog
 from pydantic import BaseSettings
-
-from pathlib import Path
-
 
 # Use environment variable to determine logging format
 # fallback to logconf.json

--- a/oidc-controller/api/main.py
+++ b/oidc-controller/api/main.py
@@ -1,27 +1,23 @@
 # import api.core.logconfig
-import logging
-import logging.config
-import structlog
 import os
 import time
 import uuid
 from pathlib import Path
 
+import structlog
 import uvicorn
 from api.core.config import settings
+from api.core.oidc.provider import init_provider
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
-from fastapi.responses import HTMLResponse
-from fastapi.middleware.cors import CORSMiddleware
 
-from .routers import acapy_handler, oidc, presentation_request, well_known_oid_config
-from .verificationConfigs.router import router as ver_configs_router
 from .clientConfigurations.router import router as client_config_router
-from .db.session import init_db, get_db
+from .db.session import get_db, init_db
+from .routers import acapy_handler, oidc, presentation_request, well_known_oid_config
 from .routers.socketio import sio_app
-
-from api.core.oidc.provider import init_provider
+from .verificationConfigs.router import router as ver_configs_router
 
 logger: structlog.typing.FilteringBoundLogger = structlog.getLogger(__name__)
 


### PR DESCRIPTION
Allow attaching a debugger to controller code. Launch configuration for VSCode:
```json
{
    "version": "0.1.0",
    "configurations": [
        {
            "name": "Python: Remote Attach",
            "type": "python",
            "request": "attach",
            "port": 5678,
            "host": "localhost",
            "pathMappings": [
                {
                    "localRoot": "${workspaceFolder}/oidc-controller",
                    "remoteRoot": "/app"
                }
            ]
        }
    ]
}
```