### PR TITLE
Feature/332 fix middleware [2.0]

### DIFF
--- a/oidc-controller/api/core/logger_util.py
+++ b/oidc-controller/api/core/logger_util.py
@@ -1,8 +1,9 @@
 import structlog
 import time
-
-
 from typing import Callable, Any
+
+logger = structlog.getLogger(__name__)
+
 
 
 def log_debug(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -20,3 +21,11 @@ def log_debug(func: Callable[..., Any]) -> Callable[..., Any]:
         return ret_val
 
     return wrapper
+
+
+def extract_error_msg_from_traceback_exc(format_exc) -> str:
+    try:
+        return format_exc.splitlines()[-1].split(": ")[1:][0]
+    except Exception:
+        logger.error(f"Failed to extract error message from traceback: {format_exc}")
+        return "Unknown error"

--- a/oidc-controller/api/core/logger_util.py
+++ b/oidc-controller/api/core/logger_util.py
@@ -2,9 +2,6 @@ import structlog
 import time
 from typing import Callable, Any
 
-logger = structlog.getLogger(__name__)
-
-
 
 def log_debug(func: Callable[..., Any]) -> Callable[..., Any]:
     def wrapper(*args, **kwargs):

--- a/oidc-controller/api/core/logger_util.py
+++ b/oidc-controller/api/core/logger_util.py
@@ -21,11 +21,3 @@ def log_debug(func: Callable[..., Any]) -> Callable[..., Any]:
         return ret_val
 
     return wrapper
-
-
-def extract_detail_from_exception(exception_only_list) -> str:
-    try:
-        return exception_only_list[0].split(": ")[1:][0].rstrip()
-    except Exception:
-        logger.error(f"Failed to get exception details from: {exception_only_list}")
-        return "Unknown error"

--- a/oidc-controller/api/core/logger_util.py
+++ b/oidc-controller/api/core/logger_util.py
@@ -23,9 +23,9 @@ def log_debug(func: Callable[..., Any]) -> Callable[..., Any]:
     return wrapper
 
 
-def extract_error_msg_from_traceback_exc(format_exc) -> str:
+def extract_detail_from_exception(exception_only_list) -> str:
     try:
-        return format_exc.splitlines()[-1].split(": ")[1:][0]
+        return exception_only_list[0].split(": ")[1:][0].rstrip()
     except Exception:
-        logger.error(f"Failed to extract error message from traceback: {format_exc}")
+        logger.error(f"Failed to get exception details from: {exception_only_list}")
         return "Unknown error"

--- a/oidc-controller/api/main.py
+++ b/oidc-controller/api/main.py
@@ -1,23 +1,29 @@
-# import api.core.logconfig
+import traceback
+import structlog
 import os
 import time
 import uuid
 from pathlib import Path
 
-import structlog
 import uvicorn
 from api.core.config import settings
-from api.core.oidc.provider import init_provider
 from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
+from fastapi.responses import JSONResponse
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi import status as http_status
 
 from .clientConfigurations.router import router as client_config_router
 from .db.session import get_db, init_db
 from .routers import acapy_handler, oidc, presentation_request, well_known_oid_config
-from .routers.socketio import sio_app
 from .verificationConfigs.router import router as ver_configs_router
+from .clientConfigurations.router import router as client_config_router
+from .db.session import init_db, get_db
+from .routers.socketio import sio_app
+from api.core.logger_util import extract_error_msg_from_traceback_exc
+from api.core.models import GenericErrorMessage
+from api.core.oidc.provider import init_provider
 
 logger: structlog.typing.FilteringBoundLogger = structlog.getLogger(__name__)
 
@@ -73,9 +79,7 @@ if origins:
 
 @app.middleware("http")
 async def logging_middleware(request: Request, call_next) -> Response:
-    # clear the threadlocal context
     structlog.threadlocal.clear_threadlocal()
-    # bind threadlocal
     structlog.threadlocal.bind_threadlocal(
         logger="uvicorn.access",
         request_id=str(uuid.uuid4()),
@@ -86,14 +90,25 @@ async def logging_middleware(request: Request, call_next) -> Response:
     start_time = time.time()
     try:
         response: Response = await call_next(request)
+        return response
     finally:
         process_time = time.time() - start_time
-        logger.info(
-            "processed a request",
-            status_code=response.status_code,
-            process_time=process_time,
-        )
-    return response
+        # If we have a response object, log the details
+        if 'response' in locals():
+            logger.info("processed a request", status_code=response.status_code, process_time=process_time)
+        # Otherwise, extract the exception from traceback, log and return a 500 response
+        else:
+            logger.info("failed to process a request", status_code=500, process_time=process_time)
+
+            # Need to explicitly log the traceback as json here. Not clear as to why.
+            if os.environ.get("LOG_WITH_JSON") is True:
+                logger.error(traceback.format_exc())
+
+            return JSONResponse(
+                status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content=GenericErrorMessage(
+                    detail=extract_error_msg_from_traceback_exc(traceback.format_exc())).dict()
+            )
 
 
 @app.on_event("startup")

--- a/oidc-controller/api/main.py
+++ b/oidc-controller/api/main.py
@@ -1,4 +1,3 @@
-import sys
 import traceback
 import structlog
 import os

--- a/oidc-controller/api/main.py
+++ b/oidc-controller/api/main.py
@@ -1,3 +1,4 @@
+import sys
 import traceback
 import structlog
 import os
@@ -21,7 +22,7 @@ from .verificationConfigs.router import router as ver_configs_router
 from .clientConfigurations.router import router as client_config_router
 from .db.session import init_db, get_db
 from .routers.socketio import sio_app
-from api.core.logger_util import extract_error_msg_from_traceback_exc
+from api.core.logger_util import extract_detail_from_exception
 from api.core.models import GenericErrorMessage
 from api.core.oidc.provider import init_provider
 
@@ -104,10 +105,11 @@ async def logging_middleware(request: Request, call_next) -> Response:
             if os.environ.get("LOG_WITH_JSON") is True:
                 logger.error(traceback.format_exc())
 
+            exc_type, exc_value, _ = sys.exc_info()
             return JSONResponse(
                 status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
                 content=GenericErrorMessage(
-                    detail=extract_error_msg_from_traceback_exc(traceback.format_exc())).dict()
+                    detail=extract_detail_from_exception(traceback.format_exception_only(exc_type, exc_value))).dict()
             )
 
 


### PR DESCRIPTION
When the logging middleware function called `call_next` and it experienced an exception then the response object is not available and would throw a response not available in locals exception that would hide the real exception. It is un-catchable in the middleware.

This checks if response object exists in the locals in the finally block, and if it does then logs the message, and if it doesn't then it assumes it's an exception and looks in traceback,  logs the stack trace and returns a 500 response with a more informative message.

The json logger didn't work with the stacktrace from call_next, which would mean the production stack traces would be invisible. Now this explicitly logs the stacktrace from the middleware if `LOG_WITH_JSON` is True.

The stacktrace for the json format (production) is a bit ugly but I can't think of a way to really make them nice so I just log it as one big string.

