### PR TITLE
Feat/335 improve error handling

### DIFF
--- a/oidc-controller/api/clientConfigurations/crud.py
+++ b/oidc-controller/api/clientConfigurations/crud.py
@@ -16,6 +16,7 @@ from .models import (
 
 logger: structlog.typing.FilteringBoundLogger = structlog.getLogger(__name__)
 
+NOT_FOUND_MSG = "The requested client configuration wasn't found"
 
 class ClientConfigurationCRUD:
     def __init__(self, db: Database):
@@ -40,7 +41,7 @@ class ClientConfigurationCRUD:
     async def get(self, client_id: str) -> ClientConfiguration:
         col = self._db.get_collection(COLLECTION_NAMES.CLIENT_CONFIGURATIONS)
         obj = col.find_one({"client_id": client_id})
-        check_and_raise_not_found_http_exception(obj)
+        check_and_raise_not_found_http_exception(obj, NOT_FOUND_MSG)
 
         return ClientConfiguration(**obj)
 
@@ -57,7 +58,7 @@ class ClientConfigurationCRUD:
             {"$set": data.dict(exclude_unset=True)},
             return_document=ReturnDocument.AFTER,
         )
-        check_and_raise_not_found_http_exception(obj)
+        check_and_raise_not_found_http_exception(obj, NOT_FOUND_MSG)
 
         # remake provider instance to refresh provider client
         await init_provider(self._db)
@@ -66,7 +67,7 @@ class ClientConfigurationCRUD:
     async def delete(self, client_id: str) -> bool:
         col = self._db.get_collection(COLLECTION_NAMES.CLIENT_CONFIGURATIONS)
         obj = col.find_one_and_delete({"client_id": client_id})
-        check_and_raise_not_found_http_exception(obj)
+        check_and_raise_not_found_http_exception(obj, NOT_FOUND_MSG)
 
         # remake provider instance to refresh provider client
         await init_provider(self._db)

--- a/oidc-controller/api/core/http_exception_util.py
+++ b/oidc-controller/api/core/http_exception_util.py
@@ -20,9 +20,12 @@ def raise_appropriate_http_exception(err: WriteError, exists_msg: str = None):
         )
 
 
-def check_and_raise_not_found_http_exception(resp):
+def check_and_raise_not_found_http_exception(resp, detail: str = None):
+    if detail is None:
+        detail = "The requested resource wasn't found"
+
     if resp is None:
         raise HTTPException(
             status_code=http_status.HTTP_404_NOT_FOUND,
-            detail="The requested resource wasn't found",
+            detail=detail,
         )

--- a/oidc-controller/api/core/http_exception_util.py
+++ b/oidc-controller/api/core/http_exception_util.py
@@ -5,8 +5,11 @@ import structlog
 
 logger = structlog.getLogger(__name__)
 
+CONFLICT_DEFAULT_MSG = "The requested resource already exists"
+NOT_FOUND_DEFAULT_MSG = "The requested resource wasn't found"
+UNKNOWN_DEFAULT_MSG = "The server was unable to process the request"
 
-def raise_appropriate_http_exception(err: WriteError, exists_msg: str = None):
+def raise_appropriate_http_exception(err: WriteError, exists_msg: str = CONFLICT_DEFAULT_MSG):
     if err.code == 11000:
         raise HTTPException(
             status_code=http_status.HTTP_409_CONFLICT,
@@ -16,14 +19,11 @@ def raise_appropriate_http_exception(err: WriteError, exists_msg: str = None):
         logger.error("Unknown error", err=err)
         raise HTTPException(
             status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="The server was unable to process the request",
+            detail=UNKNOWN_DEFAULT_MSG,
         )
 
 
-def check_and_raise_not_found_http_exception(resp, detail: str = None):
-    if detail is None:
-        detail = "The requested resource wasn't found"
-
+def check_and_raise_not_found_http_exception(resp, detail: str = NOT_FOUND_DEFAULT_MSG):
     if resp is None:
         raise HTTPException(
             status_code=http_status.HTTP_404_NOT_FOUND,

--- a/oidc-controller/api/verificationConfigs/crud.py
+++ b/oidc-controller/api/verificationConfigs/crud.py
@@ -27,7 +27,7 @@ class VerificationConfigCRUD:
             ver_confs.insert_one(jsonable_encoder(ver_config))
         except Exception as err:
             raise_appropriate_http_exception(
-                err, exists_msg="Verification configuration already exists")
+                err, exists_msg="Verifier configuration already exists")
         return ver_confs.find_one({"ver_config_id": ver_config.ver_config_id})
 
     async def get(self, ver_config_id: str) -> VerificationConfig:

--- a/oidc-controller/api/verificationConfigs/crud.py
+++ b/oidc-controller/api/verificationConfigs/crud.py
@@ -12,6 +12,7 @@ from .models import (
     VerificationConfigPatch,
 )
 
+NOT_FOUND_MSG = "The requested verifier configuration wasn't found"
 
 class VerificationConfigCRUD:
     _db: Database
@@ -32,7 +33,7 @@ class VerificationConfigCRUD:
     async def get(self, ver_config_id: str) -> VerificationConfig:
         ver_confs = self._db.get_collection(COLLECTION_NAMES.VER_CONFIGS)
         ver_conf = ver_confs.find_one({"ver_config_id": ver_config_id})
-        check_and_raise_not_found_http_exception(ver_conf)
+        check_and_raise_not_found_http_exception(ver_conf, NOT_FOUND_MSG)
 
         return VerificationConfig(**ver_conf)
 
@@ -52,7 +53,7 @@ class VerificationConfigCRUD:
             {"$set": data.dict(exclude_unset=True)},
             return_document=ReturnDocument.AFTER,
         )
-        check_and_raise_not_found_http_exception(ver_conf)
+        check_and_raise_not_found_http_exception(ver_conf, NOT_FOUND_MSG)
 
         return ver_conf
 
@@ -60,5 +61,5 @@ class VerificationConfigCRUD:
         ver_confs = self._db.get_collection(COLLECTION_NAMES.VER_CONFIGS)
         ver_conf = ver_confs.find_one_and_delete(
             {"ver_config_id": ver_config_id})
-        check_and_raise_not_found_http_exception(ver_conf)
+        check_and_raise_not_found_http_exception(ver_conf, NOT_FOUND_MSG)
         return bool(ver_conf)


### PR DESCRIPTION
When a user or perspective customer tries to use VC login without a oidc client set up they will now get a 400 error instead of 500 and it will tell them the client id they are using is invalid.

Also improved the 404 response details so if they don't have a verifier configured it will tell them the verifier they are trying to use can't be found.

Could maybe have more detail here but definitely less confusing then generic 500 responses.