### PR TITLE
Add backwards compatibility setting for token claims

### DIFF
--- a/oidc-controller/api/core/config.py
+++ b/oidc-controller/api/core/config.py
@@ -184,7 +184,6 @@ class GlobalConfig(BaseSettings):
         os.environ.get("USE_OOB_LOCAL_DID_SERVICE", False)
     )
     SET_NON_REVOKED: bool = bool(os.environ.get("SET_NON_REVOKED", True))
-    USE_V1_COMPATIBILITY: bool = bool(os.environ.get("USE_V1_COMPATIBILITY", False))
     
     class Config:
         case_sensitive = True

--- a/oidc-controller/api/core/config.py
+++ b/oidc-controller/api/core/config.py
@@ -184,7 +184,8 @@ class GlobalConfig(BaseSettings):
         os.environ.get("USE_OOB_LOCAL_DID_SERVICE", False)
     )
     SET_NON_REVOKED: bool = bool(os.environ.get("SET_NON_REVOKED", True))
-
+    USE_V1_COMPATIBILITY: bool = bool(os.environ.get("USE_V1_COMPATIBILITY", False))
+    
     class Config:
         case_sensitive = True
 

--- a/oidc-controller/api/core/oidc/issue_token_service.py
+++ b/oidc-controller/api/core/oidc/issue_token_service.py
@@ -11,7 +11,6 @@ from pydantic import BaseModel
 from ...authSessions.models import AuthSession
 from ...verificationConfigs.models import ReqAttr, VerificationConfig
 from ..models import RevealedAttribute
-from ..config import settings
 
 logger = structlog.getLogger(__name__)
 
@@ -111,7 +110,7 @@ class Token(BaseModel):
 
         # TODO: Remove after full transistion to v2.0
         # Add the presentation claims to the result as keys for backwards compatibility [v1.0]
-        if settings.USE_V1_COMPATIBILITY:
+        if ver_config.include_v1_attributes:
             for key, value in presentation_claims.items():
                 result[key] = value.value
 

--- a/oidc-controller/api/core/oidc/issue_token_service.py
+++ b/oidc-controller/api/core/oidc/issue_token_service.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 from ...authSessions.models import AuthSession
 from ...verificationConfigs.models import ReqAttr, VerificationConfig
 from ..models import RevealedAttribute
+from ..config import settings
 
 logger = structlog.getLogger(__name__)
 
@@ -107,6 +108,13 @@ class Token(BaseModel):
         result[PROOF_CLAIMS_ATTRIBUTE_NAME] = json.dumps(
             {c.type: c.value for c in presentation_claims.values()}
         )
+
+        # TODO: Remove after full transistion to v2.0
+        # Add the presentation claims to the result as keys for backwards compatibility [v1.0]
+        if settings.USE_V1_COMPATIBILITY:
+            for key, value in presentation_claims.items():
+                result[key] = value.value
+
         return result
     
     # TODO: Determine if this is useful to keep, and remove it if it's not. It is currently unused.

--- a/oidc-controller/api/core/oidc/tests/test_issue_token_service.py
+++ b/oidc-controller/api/core/oidc/tests/test_issue_token_service.py
@@ -4,6 +4,7 @@ from api.authSessions.models import AuthSession
 from api.core.oidc.issue_token_service import Token
 from api.core.oidc.tests.__mocks__ import auth_session, presentation, ver_config
 from api.test_utils import is_valid_uuid
+from api.core.config import settings
 
 basic_valid_requested_attributes = {
     "req_attr_0": {
@@ -24,6 +25,34 @@ basic_valid_revealed_attr_groups = {
             "email": {
                 "raw": "jamiehalebc@gmail.com",
                 "encoded": "73814602767252868561268261832462872577293109184327908660400248444458427915643",
+            }
+        }
+    }
+}
+
+multiple_valid_requested_attributes = {
+    "req_attr_0": {
+        "names": ["email_1", "age_1"],
+        "restrictions": [
+            {
+                "schema_name": "verified-email",
+                "issuer_did": "MTYqmTBoLT7KLP5RNfgK3b",
+            }
+        ],
+    },
+}
+
+multiple_valid_revealed_attr_groups = {
+    "req_attr_0": {
+        "sub_proof_index": 0,
+        "values": {
+            "email_1": {
+                "raw": "jamiehalebc@gmail.com",
+                "encoded": "73814602767252868561268261832462872577293109184327908660400248444458427915643",
+            },
+            "age_1": {
+                "raw": "30",
+                "encoded": "73814602767252868561268261832462872577293109184327908660400248444458427915644",
             }
         }
     }
@@ -87,36 +116,47 @@ async def test_valid_proof_presentation_with_multiple_attributes_returns_claims(
 
 
 @pytest.mark.asyncio
-async def test_valid_proof_presentation_with_one_attribute_and_multiple_values_returns_claims():
-    presentation['presentation_request']['requested_attributes'] = {
-        "req_attr_0": {
-            "names": ["email_1", "age_1"],
-            "restrictions": [
-                {
-                    "schema_name": "verified-email",
-                    "issuer_did": "MTYqmTBoLT7KLP5RNfgK3b",
-                }
-            ],
-        },
-    }
-    presentation['presentation']['requested_proof']['revealed_attr_groups'] = {
-        "req_attr_0": {
-            "sub_proof_index": 0,
-            "values": {
-                "email_1": {
-                    "raw": "jamiehalebc@gmail.com",
-                    "encoded": "73814602767252868561268261832462872577293109184327908660400248444458427915643",
-                },
-                "age_1": {
-                    "raw": "30",
-                    "encoded": "73814602767252868561268261832462872577293109184327908660400248444458427915644",
-                }
-            }
-        }
-    }
+@mock.patch.object(settings, "USE_V1_COMPATIBILITY", False)
+async def test_use_v1_compatibility_false_does_not_add_the_named_attributes():
+    presentation['presentation_request']['requested_attributes'] = multiple_valid_requested_attributes
+    presentation['presentation']['requested_proof']['revealed_attr_groups'] = multiple_valid_revealed_attr_groups
     with mock.patch.object(AuthSession, "presentation_exchange", presentation):
         claims = Token.get_claims(auth_session, ver_config)
+        vc_presented_attributes_obj = eval(claims["vc_presented_attributes"])
         assert claims is not None
+        assert vc_presented_attributes_obj["email_1"] == 'jamiehalebc@gmail.com'
+        assert vc_presented_attributes_obj["age_1"] == '30'
+        assert hasattr(claims, "email_1") is False
+        assert hasattr(claims, "age_1") is False
+
+
+@pytest.mark.asyncio
+@mock.patch.object(settings, "USE_V1_COMPATIBILITY", True)
+async def test_use_v1_compatibility_true_adds_the_named_attributes():
+    presentation['presentation_request']['requested_attributes'] = multiple_valid_requested_attributes
+    presentation['presentation']['requested_proof']['revealed_attr_groups'] = multiple_valid_revealed_attr_groups
+    with mock.patch.object(AuthSession, "presentation_exchange", presentation):
+        claims = Token.get_claims(auth_session, ver_config)
+        vc_presented_attributes_obj = eval(claims["vc_presented_attributes"])
+        assert claims is not None
+        assert vc_presented_attributes_obj["email_1"] == 'jamiehalebc@gmail.com'
+        assert vc_presented_attributes_obj["age_1"] == '30'
+        assert claims["email_1"] == 'jamiehalebc@gmail.com'
+        assert claims["age_1"] == '30'
+
+@pytest.mark.asyncio
+@mock.patch.object(settings, "USE_V1_COMPATIBILITY", None)
+async def test_use_v1_compatibility_none_does_not_add_the_named_attributes():
+    presentation['presentation_request']['requested_attributes'] = multiple_valid_requested_attributes
+    presentation['presentation']['requested_proof']['revealed_attr_groups'] = multiple_valid_revealed_attr_groups
+    with mock.patch.object(AuthSession, "presentation_exchange", presentation):
+        claims = Token.get_claims(auth_session, ver_config)
+        vc_presented_attributes_obj = eval(claims["vc_presented_attributes"])
+        assert claims is not None
+        assert vc_presented_attributes_obj["email_1"] == 'jamiehalebc@gmail.com'
+        assert vc_presented_attributes_obj["age_1"] == '30'
+        assert hasattr(claims, "email_1") is False
+        assert hasattr(claims, "age_1") is False
 
 
 @pytest.mark.asyncio
@@ -156,6 +196,7 @@ async def test_valid_presentation_with_matching_subject_identifier_has_identifie
         claims = Token.get_claims(auth_session, ver_config)
         print(claims)
         assert claims["sub"] == "jamiehalebc@gmail.com"
+
 
 @pytest.mark.asyncio
 async def test_valid_presentation_with_non_matching_subject_identifier_and_has_uuid_in_claims_sub():

--- a/oidc-controller/api/core/oidc/tests/test_issue_token_service.py
+++ b/oidc-controller/api/core/oidc/tests/test_issue_token_service.py
@@ -4,7 +4,6 @@ from api.authSessions.models import AuthSession
 from api.core.oidc.issue_token_service import Token
 from api.core.oidc.tests.__mocks__ import auth_session, presentation, ver_config
 from api.test_utils import is_valid_uuid
-from api.core.config import settings
 
 basic_valid_requested_attributes = {
     "req_attr_0": {
@@ -116,26 +115,26 @@ async def test_valid_proof_presentation_with_multiple_attributes_returns_claims(
 
 
 @pytest.mark.asyncio
-@mock.patch.object(settings, "USE_V1_COMPATIBILITY", False)
-async def test_use_v1_compatibility_false_does_not_add_the_named_attributes():
+async def test_include_v1_attributes_false_does_not_add_the_named_attributes():
     presentation['presentation_request']['requested_attributes'] = multiple_valid_requested_attributes
     presentation['presentation']['requested_proof']['revealed_attr_groups'] = multiple_valid_revealed_attr_groups
     with mock.patch.object(AuthSession, "presentation_exchange", presentation):
+        ver_config.include_v1_attributes = False
         claims = Token.get_claims(auth_session, ver_config)
         vc_presented_attributes_obj = eval(claims["vc_presented_attributes"])
         assert claims is not None
         assert vc_presented_attributes_obj["email_1"] == 'jamiehalebc@gmail.com'
         assert vc_presented_attributes_obj["age_1"] == '30'
-        assert hasattr(claims, "email_1") is False
-        assert hasattr(claims, "age_1") is False
+        assert "email_1" not in claims
+        assert "age_1" not in claims
 
 
 @pytest.mark.asyncio
-@mock.patch.object(settings, "USE_V1_COMPATIBILITY", True)
-async def test_use_v1_compatibility_true_adds_the_named_attributes():
+async def test_include_v1_attributes_true_adds_the_named_attributes():
     presentation['presentation_request']['requested_attributes'] = multiple_valid_requested_attributes
     presentation['presentation']['requested_proof']['revealed_attr_groups'] = multiple_valid_revealed_attr_groups
     with mock.patch.object(AuthSession, "presentation_exchange", presentation):
+        ver_config.include_v1_attributes = True
         claims = Token.get_claims(auth_session, ver_config)
         vc_presented_attributes_obj = eval(claims["vc_presented_attributes"])
         assert claims is not None
@@ -145,18 +144,19 @@ async def test_use_v1_compatibility_true_adds_the_named_attributes():
         assert claims["age_1"] == '30'
 
 @pytest.mark.asyncio
-@mock.patch.object(settings, "USE_V1_COMPATIBILITY", None)
-async def test_use_v1_compatibility_none_does_not_add_the_named_attributes():
+async def test_include_v1_attributes_none_does_not_add_the_named_attributes():
     presentation['presentation_request']['requested_attributes'] = multiple_valid_requested_attributes
     presentation['presentation']['requested_proof']['revealed_attr_groups'] = multiple_valid_revealed_attr_groups
     with mock.patch.object(AuthSession, "presentation_exchange", presentation):
+        ver_config.include_v1_attributes = None
+        print(ver_config.include_v1_attributes)
         claims = Token.get_claims(auth_session, ver_config)
         vc_presented_attributes_obj = eval(claims["vc_presented_attributes"])
         assert claims is not None
         assert vc_presented_attributes_obj["email_1"] == 'jamiehalebc@gmail.com'
         assert vc_presented_attributes_obj["age_1"] == '30'
-        assert hasattr(claims, "email_1") is False
-        assert hasattr(claims, "age_1") is False
+        assert "email_1" not in claims
+        assert "age_1" not in claims
 
 
 @pytest.mark.asyncio

--- a/oidc-controller/api/core/oidc/tests/test_issue_token_service.py
+++ b/oidc-controller/api/core/oidc/tests/test_issue_token_service.py
@@ -22,7 +22,7 @@ basic_valid_revealed_attr_groups = {
         "sub_proof_index": 0,
         "values": {
             "email": {
-                "raw": "jamiehalebc@gmail.com",
+                "raw": "test@email.com",
                 "encoded": "73814602767252868561268261832462872577293109184327908660400248444458427915643",
             }
         }
@@ -46,7 +46,7 @@ multiple_valid_revealed_attr_groups = {
         "sub_proof_index": 0,
         "values": {
             "email_1": {
-                "raw": "jamiehalebc@gmail.com",
+                "raw": "test@email.com",
                 "encoded": "73814602767252868561268261832462872577293109184327908660400248444458427915643",
             },
             "age_1": {
@@ -94,7 +94,7 @@ async def test_valid_proof_presentation_with_multiple_attributes_returns_claims(
             "sub_proof_index": 0,
             "values": {
                 "email": {
-                    "raw": "jamiehalebc@gmail.com",
+                    "raw": "test@email.com",
                     "encoded": "73814602767252868561268261832462872577293109184327908660400248444458427915643",
                 }
             }
@@ -123,7 +123,7 @@ async def test_include_v1_attributes_false_does_not_add_the_named_attributes():
         claims = Token.get_claims(auth_session, ver_config)
         vc_presented_attributes_obj = eval(claims["vc_presented_attributes"])
         assert claims is not None
-        assert vc_presented_attributes_obj["email_1"] == 'jamiehalebc@gmail.com'
+        assert vc_presented_attributes_obj["email_1"] == 'test@email.com'
         assert vc_presented_attributes_obj["age_1"] == '30'
         assert "email_1" not in claims
         assert "age_1" not in claims
@@ -138,9 +138,9 @@ async def test_include_v1_attributes_true_adds_the_named_attributes():
         claims = Token.get_claims(auth_session, ver_config)
         vc_presented_attributes_obj = eval(claims["vc_presented_attributes"])
         assert claims is not None
-        assert vc_presented_attributes_obj["email_1"] == 'jamiehalebc@gmail.com'
+        assert vc_presented_attributes_obj["email_1"] == 'test@email.com'
         assert vc_presented_attributes_obj["age_1"] == '30'
-        assert claims["email_1"] == 'jamiehalebc@gmail.com'
+        assert claims["email_1"] == 'test@email.com'
         assert claims["age_1"] == '30'
 
 @pytest.mark.asyncio
@@ -153,7 +153,7 @@ async def test_include_v1_attributes_none_does_not_add_the_named_attributes():
         claims = Token.get_claims(auth_session, ver_config)
         vc_presented_attributes_obj = eval(claims["vc_presented_attributes"])
         assert claims is not None
-        assert vc_presented_attributes_obj["email_1"] == 'jamiehalebc@gmail.com'
+        assert vc_presented_attributes_obj["email_1"] == 'test@email.com'
         assert vc_presented_attributes_obj["age_1"] == '30'
         assert "email_1" not in claims
         assert "age_1" not in claims
@@ -177,7 +177,7 @@ async def test_revealed_attrs_dont_match_requested_attributes_throws_exception()
             "sub_proof_index": 0,
             "values": {
                 "email-wrong": {
-                    "raw": "jamiehalebc@gmail.com",
+                    "raw": "test@email.com",
                     "encoded": "73814602767252868561268261832462872577293109184327908660400248444458427915643",
                 }
             }
@@ -195,7 +195,7 @@ async def test_valid_presentation_with_matching_subject_identifier_has_identifie
     with mock.patch.object(AuthSession, "presentation_exchange", presentation):
         claims = Token.get_claims(auth_session, ver_config)
         print(claims)
-        assert claims["sub"] == "jamiehalebc@gmail.com"
+        assert claims["sub"] == "test@email.com"
 
 
 @pytest.mark.asyncio

--- a/oidc-controller/api/verificationConfigs/examples.py
+++ b/oidc-controller/api/verificationConfigs/examples.py
@@ -1,5 +1,6 @@
 ex_ver_config = {
     "ver_config_id": "test-request-config",
+    "include_v1_attributes": False,
     "subject_identifier": "first_name",
     "proof_request": {
         "name": "Basic Proof",

--- a/oidc-controller/api/verificationConfigs/models.py
+++ b/oidc-controller/api/verificationConfigs/models.py
@@ -41,6 +41,7 @@ class VerificationProofRequest(BaseModel):
 class VerificationConfigBase(BaseModel):
     subject_identifier: str = Field()
     proof_request: VerificationProofRequest = Field()
+    include_v1_attributes: Optional[bool] = Field(default=False)
 
     def generate_proof_request(self):
         result = {


### PR DESCRIPTION
Add the environment variable and then add the attributes a separate key/value pairs to the claim object outside of the `vc_presented_attributes` object.

Set the ver_config with optional include_v1_attributes field to default False. Then when getting the claims it decides to add the attributes individually based of this ver_config setting. 

This is the claim object pulled from logs when running demo.

> {
      'pres_req_conf_id': 'verified-email', 
      'acr': 'vc_authn', 
      'nonce': 'Y-JG5tXSWN1nplex-k653A', 
      'sub': 'test@email.com', 
      'vc_presented_attributes': '{"email": "test@email.com"}', 
      'email': 'test@email.com'
 }

Resolves #347 