### PR TITLE
Remove index validation step in Helm chart releaser workflow

### DIFF
--- a/.github/workflows/chart_release.yaml
+++ b/.github/workflows/chart_release.yaml
@@ -6,27 +6,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Sometimes chart-releaser might fetch an outdated index.yaml from gh-pages, causing a WAW hazard on the repo
-  # This job checks the remote file is up to date with the local one on release
-  validate-gh-pages-index:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: gh-pages
-      - name: Download remote index file and check equality
-        run: |
-          curl -vsSL https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/index.yaml > index.yaml.remote
-          LOCAL="$(md5sum < index.yaml)"
-          REMOTE="$(md5sum < index.yaml.remote)"
-          echo "$LOCAL" = "$REMOTE"
-          test "$LOCAL" = "$REMOTE"
-
   chart-release:
     name: Create chart release
     runs-on: ubuntu-latest
-    needs: [ validate-gh-pages-index ]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
- Index validation should not be necessary here. And is hindering the first release