### PR TITLE
Fix: update subject_id that was never changing

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
       fi"
     environment:
       - DEBUGGER=${DEBUGGER}
+      - LOG_LEVEL=${LOG_LEVEL}
       - DB_HOST=${MONGODB_HOST}
       - DB_PORT=${MONGODB_PORT}
       - DB_NAME=${MONGODB_NAME}

--- a/docker/manage
+++ b/docker/manage
@@ -147,6 +147,7 @@ configureEnvironment() {
 
   ## global
   export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-vc-authn}"
+  export LOG_LEVEL=${LOG_LEVEL:-"DEBUG"}
 
   # controller-db
   export MONGODB_HOST="controller-db"

--- a/oidc-controller/api/clientConfigurations/models.py
+++ b/oidc-controller/api/clientConfigurations/models.py
@@ -1,13 +1,19 @@
 from enum import Enum
-from typing import Optional, List
+from typing import List, Optional
+
 from pydantic import BaseModel, Field
 
-from .examples import ex_client_config
 from ..core.config import settings
+from .examples import ex_client_config
 
 
 class TOKENENDPOINTAUTHMETHODS(str, Enum):
     client_secret_basic = "client_secret_basic"
+    client_secret_post = "client_secret_post"
+
+    @classmethod
+    def list(cls):
+        return list(map(lambda c: c.value, cls))
 
 
 class ClientConfigurationBase(BaseModel):

--- a/oidc-controller/api/core/oidc/issue_token_service.py
+++ b/oidc-controller/api/core/oidc/issue_token_service.py
@@ -96,7 +96,7 @@ class Token(BaseModel):
                 """subject_identifer not found in presentation values,
                   generating random subject_identifier"""
             )
-            sub_id_value = uuid.uuid4()
+            sub_id_value = str(uuid.uuid4())
         else:
             sub_id_value = sub_id_claim.value
 
@@ -115,7 +115,7 @@ class Token(BaseModel):
                 result[key] = value.value
 
         return result
-    
+
     # TODO: Determine if this is useful to keep, and remove it if it's not. It is currently unused.
     # renames and calculates dict members appropriate to
     # https://openid.net/specs/openid-connect-core-1_0.html#IDToken

--- a/oidc-controller/requirements-dev.txt
+++ b/oidc-controller/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest-asyncio==0.21.1
 pytest-cov==4.1.0
 pytest==7.3.1
 requests-mock==1.11.0
+setuptools==68.2.2


### PR DESCRIPTION
Fixes an issue that caused all `subject_id` values to always be the same, regardless of the proof used to authenticate.
Fixes an issue related to non-serializable values when no subject identifier was available from the proof-request.

Also adds support for sending client secret in the POST body rather than using basic-auth.

Resolves #358 