### PR TITLE
Properly toggle JSON logging

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
     environment:
       - DEBUGGER=${DEBUGGER}
       - LOG_LEVEL=${LOG_LEVEL}
+      - LOG_WITH_JSON=${LOG_WITH_JSON}
       - DB_HOST=${MONGODB_HOST}
       - DB_PORT=${MONGODB_PORT}
       - DB_NAME=${MONGODB_NAME}

--- a/oidc-controller/api/core/config.py
+++ b/oidc-controller/api/core/config.py
@@ -11,11 +11,29 @@ from typing import Optional, Union
 import structlog
 from pydantic import BaseSettings
 
+# Removed in later versions of python
+def strtobool (val: str | bool) -> bool:
+    """Convert a string representation of truth to a boolean (True or False).
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; False
+    values are 'n', 'no', 'f', 'false', 'off', and '0'. If val is
+    already a boolean it is simply returned.  Raises ValueError if
+    'val' is anything else.
+    """
+    if isinstance(val, bool):
+        return val
+
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return True
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return False
+    else:
+        raise ValueError(f"invalid truth value {val}")
+
 # Use environment variable to determine logging format
-# fallback to logconf.json
-# finally default to true
-# bool() is needed to coerce the results of the environment variable
-use_json_logs: bool = bool(os.environ.get("LOG_WITH_JSON", True))
+# default to True
+# strtobool will convert the results of the environment variable to a bool
+use_json_logs: bool =  strtobool(os.environ.get("LOG_WITH_JSON", True))
 
 time_stamp_format: str = os.environ.get("LOG_TIMESTAMP_FORMAT", "iso")
 
@@ -179,12 +197,11 @@ class GlobalConfig(BaseSettings):
 
     # OIDC Controller Settings
     CONTROLLER_API_KEY: str = os.environ.get("CONTROLLER_API_KEY", "")
-    USE_OOB_PRESENT_PROOF: bool = bool(os.environ.get("USE_OOB_PRESENT_PROOF", False))
-    USE_OOB_LOCAL_DID_SERVICE: bool = bool(
+    USE_OOB_PRESENT_PROOF: bool = strtobool(os.environ.get("USE_OOB_PRESENT_PROOF", False))
+    USE_OOB_LOCAL_DID_SERVICE: bool = strtobool(
         os.environ.get("USE_OOB_LOCAL_DID_SERVICE", False)
     )
-    SET_NON_REVOKED: bool = bool(os.environ.get("SET_NON_REVOKED", True))
-    
+    SET_NON_REVOKED: bool = strtobool(os.environ.get("SET_NON_REVOKED", True))
     class Config:
         case_sensitive = True
 

--- a/oidc-controller/api/main.py
+++ b/oidc-controller/api/main.py
@@ -92,15 +92,22 @@ async def logging_middleware(request: Request, call_next) -> Response:
     finally:
         process_time = time.time() - start_time
         # If we have a response object, log the details
-        if 'response' in locals():
-            logger.info("processed a request", status_code=response.status_code, process_time=process_time)
+        if "response" in locals():
+            logger.info(
+                "processed a request",
+                status_code=response.status_code,
+                process_time=process_time,
+            )
         # Otherwise, extract the exception from traceback, log and return a 500 response
         else:
-            logger.info("failed to process a request", status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR, process_time=process_time)
+            logger.info(
+                "failed to process a request",
+                status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+                process_time=process_time,
+            )
 
-            # Need to explicitly log the traceback as json here. Not clear as to why.
-            if os.environ.get("LOG_WITH_JSON", True) is True:
-                logger.error(traceback.format_exc())
+            # Need to explicitly log the traceback
+            logger.error(traceback.format_exc())
 
             return JSONResponse(
                 status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
This PR resolves #363
Since there are multiple ways individuals could pass a true or false as an environmental variable I added a dedicated function strtobool based on [distutils.util.strtobool](https://docs.python.org/3.9/distutils/apiref.html#distutils.util.strtobool) which will be removed in python 3.12. In addition, I have made the logging of stack traces independent of logging format.

Here is the regular text logging:
![2023-10-27_10-45-05](https://github.com/bcgov/vc-authn-oidc/assets/34443260/548ed33a-dda3-4d11-97d0-552a5b05fcf0)

Here is the json version:
![2023-10-27_10-47-03](https://github.com/bcgov/vc-authn-oidc/assets/34443260/1fdffbaa-e603-4bb4-9313-bce5d6a13f23)

