### PR TITLE
Provide unique, consistent user identifier for repeated authentication attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ curl -X 'POST' \
   -d '{
   "ver_config_id": "verified-email",
   "subject_identifier": "email",
+  "generate_consistent_identifier": true,
   "proof_request": {
     "name": "BCGov Verified Email",
     "version": "1.0",

--- a/docs/README.md
+++ b/docs/README.md
@@ -310,7 +310,7 @@ To quote from the OpenID Connect specification on [ID tokens](https://openid.net
 
 `sub : REQUIRED. Subject Identifier. A locally unique and never reassigned identifier within the Issuer for the End-User, which is intended to be consumed by the Client, e.g., 24400320 or AItOawmwtWwcT0k51BayewNvutrJUqsvl6qs7A4. It MUST NOT exceed 255 ASCII characters in length. The sub value is a case sensitive string`
 
-When an OP is performing VC-AuthN, and the request has reached the point where the VC presentation has been generated and sent by the IW to the OP, the OP must now map contents of this VC presentation to an OpenID ID token. The question is then raised on what should populate this field. The three available are:
+When an OP is performing VC-AuthN, and the request has reached the point where the VC presentation has been generated and sent by the IW to the OP, the OP must now map contents of this VC presentation to an OpenID ID token. The question is then raised on what should populate this field. The three options available are:
 
 1. Nominate a disclosed attribute in the verifiable credential presentation that is used to populate the subject field.
 2. Ephemeral generate an identifier for this field e.g a randomly generated GUID.

--- a/docs/README.md
+++ b/docs/README.md
@@ -138,6 +138,7 @@ A verifiable credential presentation request configuration, takes the following 
 {
   "id": "<configuration-identifier>",
   "subject_identifier": "<attribute-name>",
+  "generate_consistent_identifier": <true|false>,
   "proof_request": {
     "name": "Basic Proof",
     "version": "1.0",
@@ -156,6 +157,7 @@ This data model is inspired by that is defined and used in the [Hyperledger Indy
 
 - `id` : The identifier for the presentation configuration.
 - `subject_identifier` : See [here](#subject-identifer-mapping) for further details on the purpose of this field.
+- `generate_consistent_identifier` : Optional field defaulting to false. See [here](#subject-identifer-mapping) for more details.
 - `proof_request` : Contains the details on the presentation request, e.g which attributes are to be disclosed
     - `name` : The name that will accompany the presentation request
     - `version` : The version of the presentation request
@@ -308,7 +310,7 @@ To quote from the OpenID Connect specification on [ID tokens](https://openid.net
 
 `sub : REQUIRED. Subject Identifier. A locally unique and never reassigned identifier within the Issuer for the End-User, which is intended to be consumed by the Client, e.g., 24400320 or AItOawmwtWwcT0k51BayewNvutrJUqsvl6qs7A4. It MUST NOT exceed 255 ASCII characters in length. The sub value is a case sensitive string`
 
-When an OP is performing VC-AuthN, and the request has reached the point where the VC presentation has been generated and sent by the IW to the OP, the OP must now map contents of this VC presentation to an OpenID ID token. The question is then raised on what should populate this field. The two options available are:
+When an OP is performing VC-AuthN, and the request has reached the point where the VC presentation has been generated and sent by the IW to the OP, the OP must now map contents of this VC presentation to an OpenID ID token. The question is then raised on what should populate this field. The three available are:
 
 1. Nominate a disclosed attribute in the verifiable credential presentation that is used to populate the subject field.
 2. Ephemeral generate an identifier for this field e.g a randomly generated GUID.
@@ -317,6 +319,7 @@ When an OP is performing VC-AuthN, and the request has reached the point where t
 **Note:**
 - In option 2. this prevents the often desirable property of cross session correlation of an authenticated user, which will effect the ability for many integrating IAM solutions being able to conduct effective auditing.
 - In option 3. this method should be assessed and used with caution, as the chance of collisions for users holding credentials with exact same values is possible (e.g.: a proof-request using only `first_name` and `last_name`, would generate the same identifier for people with same first and last name).
+- In order to enable option 3 the _presentation request configuration_ must have `generate_consistent_identifier`
 
 #### UserInfo Endpoint
 

--- a/oidc-controller/api/core/models.py
+++ b/oidc-controller/api/core/models.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import TypedDict
 
 from bson import ObjectId
 from pydantic import BaseModel, Field
@@ -48,7 +49,10 @@ class GenericErrorMessage(BaseModel):
     detail: str
 
 
-class RevealedAttribute(BaseModel):
+# Currently used as a TypedDict since it can be used as a part of a
+# Pydantic class but a Pydantic class can not inherit from TypedDict
+# and and BaseModel
+class RevealedAttribute(TypedDict, total=False):
     sub_proof_index: int
     values: dict
 

--- a/oidc-controller/api/core/oidc/tests/test_issue_token_service.py
+++ b/oidc-controller/api/core/oidc/tests/test_issue_token_service.py
@@ -261,3 +261,15 @@ async def test_valid_presentation_with_non_matching_subject_identifier_and_gener
         ver_config.generate_consistent_identifier = True
         claims = Token.get_claims(auth_session, ver_config)
         assert "sub" in claims
+
+        # Ensure that this sub is not using the ver_config.subject_identifier
+        ver_config.subject_identifier = "email"
+        ver_config.generate_consistent_identifier = False
+        claims_subject_identifier = Token.get_claims(auth_session, ver_config)
+        assert claims["sub"] != claims_subject_identifier["sub"]
+
+        # Ensure that sub is consistent
+        ver_config.subject_identifier = "not-email"
+        ver_config.generate_consistent_identifier = True
+        claims_duplicate = Token.get_claims(auth_session, ver_config)
+        assert claims["sub"] == claims_duplicate["sub"]

--- a/oidc-controller/api/core/oidc/tests/test_issue_token_service.py
+++ b/oidc-controller/api/core/oidc/tests/test_issue_token_service.py
@@ -219,7 +219,7 @@ async def test_valid_presentation_with_matching_subject_identifier_has_identifie
 
 
 @pytest.mark.asyncio
-async def test_valid_presentation_with_non_matching_subject_identifier_and_has_no_sub():
+async def test_valid_presentation_with_non_matching_subject_identifier_and_generate_consistent_identifier_is_missing_and_has_no_sub():
     presentation["presentation_request"][
         "requested_attributes"
     ] = basic_valid_requested_attributes
@@ -229,4 +229,35 @@ async def test_valid_presentation_with_non_matching_subject_identifier_and_has_n
     with mock.patch.object(AuthSession, "presentation_exchange", presentation):
         ver_config.subject_identifier = "not-email"
         claims = Token.get_claims(auth_session, ver_config)
+        assert not ver_config.generate_consistent_identifier
         assert "sub" not in claims
+
+
+@pytest.mark.asyncio
+async def test_valid_presentation_with_non_matching_subject_identifier_and_generate_consistent_identifier_false_and_has_no_sub():
+    presentation["presentation_request"][
+        "requested_attributes"
+    ] = basic_valid_requested_attributes
+    presentation["presentation"]["requested_proof"][
+        "revealed_attr_groups"
+    ] = basic_valid_revealed_attr_groups
+    with mock.patch.object(AuthSession, "presentation_exchange", presentation):
+        ver_config.subject_identifier = "not-email"
+        ver_config.generate_consistent_identifier = False
+        claims = Token.get_claims(auth_session, ver_config)
+        assert "sub" not in claims
+
+
+@pytest.mark.asyncio
+async def test_valid_presentation_with_non_matching_subject_identifier_and_generate_consistent_identifier_true_and_has_sub():
+    presentation["presentation_request"][
+        "requested_attributes"
+    ] = basic_valid_requested_attributes
+    presentation["presentation"]["requested_proof"][
+        "revealed_attr_groups"
+    ] = basic_valid_revealed_attr_groups
+    with mock.patch.object(AuthSession, "presentation_exchange", presentation):
+        ver_config.subject_identifier = "not-email"
+        ver_config.generate_consistent_identifier = True
+        claims = Token.get_claims(auth_session, ver_config)
+        assert "sub" in claims

--- a/oidc-controller/api/verificationConfigs/examples.py
+++ b/oidc-controller/api/verificationConfigs/examples.py
@@ -1,6 +1,7 @@
 ex_ver_config = {
     "ver_config_id": "test-request-config",
     "include_v1_attributes": False,
+    "generate_consistent_identifier": False,
     "subject_identifier": "first_name",
     "proof_request": {
         "name": "Basic Proof",

--- a/oidc-controller/api/verificationConfigs/models.py
+++ b/oidc-controller/api/verificationConfigs/models.py
@@ -41,6 +41,7 @@ class VerificationProofRequest(BaseModel):
 class VerificationConfigBase(BaseModel):
     subject_identifier: str = Field()
     proof_request: VerificationProofRequest = Field()
+    generate_consistent_identifier: Optional[bool] = Field(default=False)
     include_v1_attributes: Optional[bool] = Field(default=False)
 
     def generate_proof_request(self):
@@ -52,8 +53,7 @@ class VerificationConfigBase(BaseModel):
         }
         for i, req_attr in enumerate(self.proof_request.requested_attributes):
             label = req_attr.label or "req_attr_" + str(i)
-            result["requested_attributes"][label] = req_attr.dict(
-                exclude_none=True)
+            result["requested_attributes"][label] = req_attr.dict(exclude_none=True)
             if settings.SET_NON_REVOKED:
                 result["requested_attributes"][label]["non_revoked"] = {
                     "from": int(time.time()),
@@ -62,8 +62,7 @@ class VerificationConfigBase(BaseModel):
         # TODO add I indexing
         for req_pred in self.proof_request.requested_predicates:
             label = req_pred.label or "req_pred_" + str(i)
-            result["requested_predicates"][label] = req_pred.dict(
-                exclude_none=True)
+            result["requested_predicates"][label] = req_pred.dict(exclude_none=True)
             if settings.SET_NON_REVOKED:
                 result["requested_attributes"][label]["non_revoked"] = {
                     "from": int(time.time()),

--- a/oidc-controller/requirements.txt
+++ b/oidc-controller/requirements.txt
@@ -8,3 +8,4 @@ qrcode[pil]==7.4.2
 structlog==23.1.0
 uvicorn[standard]==0.22.0
 python-socketio==5.8.0 # required to run websockets
+canonicaljson==2.0.0 # used to provide unique consistent user identifiers


### PR DESCRIPTION
When authenticating with VC-AuthN, there are currently two options for generating a `subject_identifier` for the authenticated user:
- Using one of the proof-request attributes, if available and configured in the proof-configuration
- Generating a new identifier for each authentication attempt

The first option is only available IF the VCs used to authenticate provide a unique identifier: this would be configured in the proof-configuration to be used as `sub`, and would be passed along to the relying party that initiated the authentication request.

The issue with this pattern when integrating VC-AuthN into an AIM system such as Keycloak is that, unless a unique user identifier is generated by VC-AuthN, it will not be possible to associate roles to the user account in the AIM system as every authentication attempt will appear as a new user trying to access the system.

**Proposed solution:**
Rather than generating a new random user identifier for every authentication attempt, VC-AuthN would generate a consistent user identifier by hashing a canonicalized version of the JSON containing the claims obtained from the proof-request.

Possible library to canonicalize JSON: https://pypi.org/project/canonicaljson/

The underlying Pyop library will generate a new value for the `sub` if non is provided. A couple of places we could look at plugging-in the generation of the subject identifier value:
- [here](https://github.com/bcgov/vc-authn-oidc/blob/0cc400380541e7fcf9d2fb75f909782380984150/oidc-controller/api/routers/oidc.py#L173-L184) to generate the sub *BEFORE* pyop takes over to generate the token
- by implementing a new [SubjectidentifierFactory](src/pyop/subject_identifier.py) matching our criteria and injecting it in the code at the right time ([here](https://github.com/bcgov/vc-authn-oidc/blob/0cc400380541e7fcf9d2fb75f909782380984150/oidc-controller/api/core/oidc/provider.py#L118)).