### PR TITLE
Add Code Coverage Reports

### DIFF
--- a/.github/workflows/controller_unittests.yml
+++ b/.github/workflows/controller_unittests.yml
@@ -37,10 +37,13 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         working-directory: ./oidc-controller
+        flag-name: tests-${{ matrix.python-version }}
         run: |
           pytest --log-cli-level=INFO --cov --cov-report lcov
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:
+          parallel-finished: true
+          carryforward: "tests-3.11"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: coverage.lcov

--- a/.github/workflows/controller_unittests.yml
+++ b/.github/workflows/controller_unittests.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11"]
-
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -37,7 +36,6 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         working-directory: ./oidc-controller
-        flag-name: tests-${{ matrix.python-version }}
         run: |
           pytest --log-cli-level=INFO --cov --cov-report lcov
       - name: Coveralls Parallel

--- a/.github/workflows/controller_unittests.yml
+++ b/.github/workflows/controller_unittests.yml
@@ -44,7 +44,7 @@ jobs:
           flag-name: run-${{ matrix.python-version }}
           parallel: true
   finish:
-    needs: test
+    needs: build
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/controller_unittests.yml
+++ b/.github/workflows/controller_unittests.yml
@@ -3,11 +3,10 @@ name: Controller Unit Tests
 on:
   push:
     branches:
-      - '2.0-development'
+      - "main"
   pull_request:
     branches:
-      - '2.0-development'
-    
+      - "main"
 
 jobs:
   build:
@@ -39,4 +38,9 @@ jobs:
       - name: Test with pytest
         working-directory: ./oidc-controller
         run: |
-          pytest --log-cli-level=INFO
+          pytest --log-cli-level=INFO --cov --cov-report lcov
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage.lcov

--- a/.github/workflows/controller_unittests.yml
+++ b/.github/workflows/controller_unittests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v2
         with:
-          flag-name: run-${{ matrix.python-version }}
+          flag-name: python-${{ matrix.python-version }}
           parallel: true
   code-coverage:
     name: Generate Code Coverage
@@ -53,4 +53,4 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           parallel-finished: true
-          carryforward: "run-3.11"
+          carryforward: "python-3.11"

--- a/.github/workflows/controller_unittests.yml
+++ b/.github/workflows/controller_unittests.yml
@@ -40,10 +40,18 @@ jobs:
         flag-name: tests-${{ matrix.python-version }}
         run: |
           pytest --log-cli-level=INFO --cov --cov-report lcov
-      - name: Coveralls
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@v2
+        with:
+          flag-name: run-${{ matrix.python-version }}
+          parallel: true
+  finish:
+    needs: test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
         uses: coverallsapp/github-action@v2
         with:
           parallel-finished: true
-          carryforward: "tests-3.11"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: coverage.lcov
+          carryforward: "run-3.11"

--- a/.github/workflows/controller_unittests.yml
+++ b/.github/workflows/controller_unittests.yml
@@ -43,7 +43,8 @@ jobs:
         with:
           flag-name: run-${{ matrix.python-version }}
           parallel: true
-  finish:
+  code-coverage:
+    name: Generate Code Coverage
     needs: build
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 [![unit-tests](https://github.com/bcgov/vc-authn-oidc/actions/workflows/controller_unittests.yml/badge.svg?branch=2.0-development&event=push)](https://github.com/bcgov/vc-authn-oidc/actions/workflows/controller_unittests.yml)
-[![Coverage Status](https://coveralls.io/repos/github/bcgov/vc-authn-oidc/badge.svg?branch=main)](https://coveralls.io/repos/github/bcgov/vc-authn-oidc/badge.svg?branch=main)
+[![Coverage Status](https://coveralls.io/repos/github/Gavinok/vc-authn-oidc/badge.svg?branch=main)](https://coveralls.io/repos/github/Gavinok/vc-authn-oidc/badge.svg?branch=main)
 
 # Verifiable Credential Authentication with OpenID Connect (VC-AuthN OIDC)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 [![unit-tests](https://github.com/bcgov/vc-authn-oidc/actions/workflows/controller_unittests.yml/badge.svg?branch=2.0-development&event=push)](https://github.com/bcgov/vc-authn-oidc/actions/workflows/controller_unittests.yml)
-[![Coverage Status](https://coveralls.io/repos/github/Gavinok/vc-authn-oidc/badge.svg?branch=main)](https://coveralls.io/repos/github/Gavinok/vc-authn-oidc/badge.svg?branch=main)
+[![Coverage Status](https://coveralls.io/repos/github/bcgov/vc-authn-oidc/badge.svg?branch=main)](https://coveralls.io/repos/github/bcgov/vc-authn-oidc/badge.svg?branch=main)
 
 # Verifiable Credential Authentication with OpenID Connect (VC-AuthN OIDC)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 [![unit-tests](https://github.com/bcgov/vc-authn-oidc/actions/workflows/controller_unittests.yml/badge.svg?branch=2.0-development&event=push)](https://github.com/bcgov/vc-authn-oidc/actions/workflows/controller_unittests.yml)
+[![Coverage Status](https://coveralls.io/repos/github/bcgov/vc-authn-oidc/badge.svg?branch=main)](https://coveralls.io/repos/github/bcgov/vc-authn-oidc/badge.svg?branch=main)
 
 # Verifiable Credential Authentication with OpenID Connect (VC-AuthN OIDC)
 


### PR DESCRIPTION
This PR resolves #316 by adding code coverage reports using [coveralls](https://coveralls.io/) for pull requests as well as adding a badge to the README indicating the current test coverage for the main branch.

There may be an additional permission I am missing since Coveralls is able to post the test results just fine on [my repo](https://github.com/Gavinok/vc-authn-oidc/pull/2) but not on the bcgov one