### PR TITLE
Handle Declined proof (abandoned state callback)

### DIFF
--- a/oidc-controller/api/authSessions/models.py
+++ b/oidc-controller/api/authSessions/models.py
@@ -15,6 +15,7 @@ class AuthSessionState(StrEnum):
     EXPIRED = auto()
     VERIFIED = auto()
     FAILED = auto()
+    ABANDONED = auto()
 
 class AuthSessionBase(BaseModel):
     pres_exch_id: str

--- a/oidc-controller/api/routers/acapy_handler.py
+++ b/oidc-controller/api/routers/acapy_handler.py
@@ -61,6 +61,16 @@ async def post_topic(request: Request, topic: str, db: Database = Depends(get_db
                 await AuthSessionCRUD(db).patch(
                     str(auth_session.id), AuthSessionPatch(**auth_session.dict())
                 )
+            
+            # abandoned state
+            if webhook_body["state"] == "abandoned":
+                logger.info("ABANDONED")
+                logger.info(webhook_body["error_msg"])
+                auth_session.proof_status = AuthSessionState.ABANDONED
+                await sio.emit("status", {"status": "abandoned"}, to=sid)
+                await AuthSessionCRUD(db).patch(
+                    str(auth_session.id), AuthSessionPatch(**auth_session.dict())
+                )
 
             # Calcuate the expiration time of the proof
             now_time = datetime.now()

--- a/oidc-controller/api/templates/verified_credentials.html
+++ b/oidc-controller/api/templates/verified_credentials.html
@@ -136,6 +136,7 @@
       .header-desc.success,
       .header-desc.pending,
       .header-desc.expired,
+      .header-desc.abandoned,
       .header-desc.failed {
         display: none;
         border-radius: 0.5rem;
@@ -165,6 +166,9 @@
       }
       .header-desc.success {
         background-color: #dff0d8;
+      }
+      .header-desc.abandoned {
+        background-color: #f2dede;
       }
       .header-desc a {
         line-height: 1rem;
@@ -215,6 +219,18 @@
             >
           </div>
         </div>
+
+        <div class="header-desc abandoned">
+           <div class="qr-code-image">{{add_asset("circle-x.svg")}}</div>
+           <div class="qr-code-desc">
+             <b>Proof declined</b>
+             </br>
+             <a href="javascript:window.location.reload(true)"
+              title="Refresh QR code."
+               >Try again.</a
+             >
+           </div>
+         </div>
 
         <div class="header-desc pending">
           <div class="qr-code-image">{{add_asset("hourglass.svg")}}</div>
@@ -273,93 +289,27 @@
     socket.connect();
 
     const toggleState = (state) => {
-      const intro = document.querySelector(".intro");
-      const success = document.querySelector(".success");
-      const pending = document.querySelector(".pending");
-      const failed = document.querySelector(".failed");
-      const expired = document.querySelector(".expired");
-      const qrcode = document.querySelector(".qr-code");
-      const scannedMask = document.querySelector(".scanned-mask");
-      const refreshButton = document.getElementById("refresh-button");
-
       switch (state) {
         case "intro":
-          // Header elements
-          intro.style.display = "grid";
-          success.style.display = "none";
-          pending.style.display = "none";
-          failed.style.display = "none";
-          expired.style.display = "none";
-
-          // Button elements
-          refreshButton.style.display = "none";
-
-          // Turn off the spinner
-          qrcode.classList.remove("pending");
+          setUiElements(".intro", false, false, false);
           break;
         case "verified":
-          // Header elements
-          intro.style.display = "none";
-          success.style.display = "grid";
-          pending.style.display = "none";
-          failed.style.display = "none";
-          expired.style.display = "none";
-
-          // Button elements
-          refreshButton.style.display = "none";
-          scannedMask.style.display = "flex";
-
-          // Turn off the spinner
-          qrcode.classList.remove("pending");
-
+          setUiElements(".success", false, true, false);
           setTimeout(() => {
             window.location.replace("{{callback_url}}", { method: "POST" });
           }, 2000);
           break;
         case "failed":
-          // Header elements
-          intro.style.display = "none";
-          success.style.display = "none";
-          pending.style.display = "none";
-          failed.style.display = "grid";
-          expired.style.display = "none";
-
-          // Button elements
-          refreshButton.style.display = "flex";
-          scannedMask.style.display = "none";
-
-          // Turn off the spinner
-          qrcode.classList.remove("pending");
+          setUiElements(".failed", true, false, false);
           break;
         case "pending":
-          // Header elements
-          intro.style.display = "none";
-          success.style.display = "none";
-          pending.style.display = "grid";
-          failed.style.display = "none";
-          expired.style.display = "none";
-
-          // Button elements
-          refreshButton.style.display = "none";
-          scannedMask.style.display = "flex";
-
-          // Turn on the spinner
-          qrcode.classList.add("pending");
+          setUiElements(".pending", false, true, true);
           break;
         case "expired":
-          // Header elements
-          intro.style.display = "none";
-          success.style.display = "none";
-          pending.style.display = "none";
-          failed.style.display = "none";
-          expired.style.display = "grid";
-
-          // Button elements
-          refreshButton.style.display = "flex";
-          scannedMask.style.display = "none";
-
-          // Turn off the spinner
-          qrcode.classList.remove("pending");
+          setUiElements(".expired", true, false, false);
+          break;
+        case "abandoned":
+          setUiElements(".abandoned", true, false, false);
           break;
         }
     };
@@ -367,6 +317,29 @@
     document.getElementById("refresh-button").addEventListener("click", () => {
       location.reload(true);
     });
+
+    /**
+     * Set the UI elements based on the current state
+     */
+    const setUiElements = (state, showRefresh, showScanned, setSpinner) => {
+      const stateElement = document.querySelector(state);
+      const qrcode = document.querySelector(".qr-code");
+      const scannedMask = document.querySelector(".scanned-mask");
+      const refreshButton = document.getElementById("refresh-button");
+
+      // set all elements to display: none and display the current state
+      document.querySelectorAll(".header-desc").forEach((el) => {
+        el.style.display = "none";
+      });
+      stateElement.style.display = "grid";
+
+      // set the refresh and/or scanned overlays
+      refreshButton.style.display = showRefresh ? "flex" : "none";
+      scannedMask.style.display = showScanned ? "flex" : "none";
+
+      // add or remove 'pending' class from qrcode based on setSpinner
+      qrcode.classList.toggle("pending", setSpinner);
+    }
 
     let timer;
 


### PR DESCRIPTION
**NOTE:** For this to function a subsequent upcoming change to ACA-Py will need to be released. ACA-Py currently does not send a problem report for abandoned presentations on connectionless presentation requests. The change to remove this restriction will need to be accepted and released.

However, on the VCAuthn side, this is just adding a new state handler, so this could conceivably be merged in without any adverse affects, the state just won't be triggered unless the ACA-Py change is in place.

---

Add a state handler in the controller acapy handler for a `present_proof` topic that contains a state `abandoned` (which is triggered when the user declines a presentation request).

The topic handler in the existing code already checks the incoming webhook `presentation_exchange_id` to get the appropriate auth session. So add a new check for abandoned state and emit that to the handler to display the HTML page with the new state. 
The state is just "abandoned", the error message says `abandoned: Declined` so possibly could parse out more if there were multiple `abandoned` cases to handle... but that would be relying on a text error message display rather than state.

See object contents from debug session below:
![image](https://github.com/bcgov/vc-authn-oidc/assets/17445138/dc522dfa-97f2-4116-87c3-c2015c7ae8ae)




Alter the frontend page to handle this state. It looks like below and the user can hit try again or refresh to do a proof again if they accidentally decline. Can adjust wording/icon/color if needed.

![image](https://github.com/bcgov/vc-authn-oidc/assets/17445138/f3e24c4c-0176-4f5a-8b95-3dbb0a75f5d8)

Additionally refactor the JS in the HTML file to generalize the UI element setup and reduce duplication.
