### PR TITLE
2.0.0 release

### DIFF
--- a/charts/vc-authn-oidc/Chart.yaml
+++ b/charts/vc-authn-oidc/Chart.yaml
@@ -12,7 +12,7 @@ version: 0.1.7
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.0-rc2"
+appVersion: "2.0.0"
 
 # Charts the vc-authn-oidc service depends on 
 dependencies:

--- a/charts/vc-authn-oidc/README.md
+++ b/charts/vc-authn-oidc/README.md
@@ -1,6 +1,6 @@
 # VC-AuthN OIDC
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0-rc2](https://img.shields.io/badge/AppVersion-2.0.0--rc2-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart to deploy Verifiable Credential Identity Provider for OpenID Connect.
 


### PR DESCRIPTION
Prepare for official 2.0.0 release. Chart files already appear up-to-date (next chart version is `0.1.7`).