### PR TITLE
Display pres req link for debugging

### DIFF
--- a/demo/vue/app/frontend/src/router/index.js
+++ b/demo/vue/app/frontend/src/router/index.js
@@ -88,7 +88,7 @@ export default function getRouter(basePath = '/') {
         document.title = to.meta.title
           ? to.meta.title
           : process.env.VUE_APP_TITLE;
-      } else document.title = 'Demo VC-Authn-OIDC App”'; // default title
+      } else document.title = 'Demo VC-Authn-OIDC App'; // default title
 
       if (to.query.r && isFirstTransition) {
         router.replace({

--- a/oidc-controller/api/templates/verified_credentials.html
+++ b/oidc-controller/api/templates/verified_credentials.html
@@ -408,7 +408,7 @@
     }, 2000);
 
     /**
-     * If the BC_ID is clicked on 10 times in a row, the QR code will be refreshed
+     * If the BC_ID is clicked on 10 times in a row, display the link textbox
      */
     let counter = 0;
     const textLinkDiv = document.querySelector(".text-link");

--- a/oidc-controller/api/templates/verified_credentials.html
+++ b/oidc-controller/api/templates/verified_credentials.html
@@ -173,6 +173,21 @@
       .header-desc a {
         line-height: 1rem;
       }
+      .text-link {
+        display: none;
+        margin-top: 1rem;
+        margin-bottom: 1rem;
+      }
+      .text-link textarea {
+        border-radius: 5px;
+        display: block;
+        max-width: 100%;
+        resize: none;
+        width: 100%;
+      }
+      .text-link label {
+        display: block;
+      }
     </style>
   </head>
   <body>
@@ -258,6 +273,17 @@
             width="300px"
             height="300px"
           />
+        </div>
+
+        <!-- Add a input box with the url_to_message data -->
+        <div class="text-link">
+          <label for="url_to_message">Presentation Exchange URL:</label>
+          <textarea
+            id="url_to_message"
+            rows="3"
+            disabed
+            value="{{url_to_message}}"
+          >{{url_to_message}}</textarea>
         </div>
 
         <div>
@@ -380,5 +406,17 @@
     timer = setInterval(() => {
       checkStatus();
     }, 2000);
+
+    /**
+     * If the BC_ID is clicked on 10 times in a row, the QR code will be refreshed
+     */
+    let counter = 0;
+    const textLinkDiv = document.querySelector(".text-link");
+    document.querySelector("#BC_ID").addEventListener("click", () => {
+      counter++;
+      if (counter === 10) {
+        textLinkDiv.style.display = "block";
+      }
+    });
   </script>
 </html>


### PR DESCRIPTION
(this is not related to BC Wallet deep link feature upcoming)

It's onerous to debug the QR code link on a VCAuth login. Have to snip code out, save, upload to a qr decode or something like that. Would be good to just see the pure text link that's converted to the QR Code.

Can use this to debug locally, or if needed do operational support for a user that's having an issue with the QR code.

Add an easter egg (BC Wallet style, tap 10 times on the BC Gov logo) that exposes the link in a textbox

![image](https://github.com/bcgov/vc-authn-oidc/assets/17445138/37c4f9e8-7e84-456b-9276-2f1e1303367e)
