### PR TITLE
BC Wallet deep link display

### DIFF
--- a/oidc-controller/api/authSessions/models.py
+++ b/oidc-controller/api/authSessions/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from enum import StrEnum, auto
-from typing import Dict
+from typing import Dict, Optional
 
 from api.core.acapy.client import AcapyClient
 from api.core.models import UUIDModel
@@ -25,6 +25,7 @@ class AuthSessionBase(BaseModel):
     request_parameters: dict
     pyop_auth_code: str
     response_url: str
+    presentation_request_msg: Optional[dict] = None
 
     class Config:
         allow_population_by_field_name = True

--- a/oidc-controller/api/routers/oidc.py
+++ b/oidc-controller/api/routers/oidc.py
@@ -129,6 +129,10 @@ async def get_authorize(request: Request, db: Database = Depends(get_db)):
     image_contents = base64.b64encode(buff.getvalue()).decode("utf-8")
     callback_url = f"""{controller_host}{AuthorizeCallbackUri}?pid={auth_session.id}"""
 
+    # BC Wallet deep link
+    response_b64 = base64.b64encode(response.json().encode("utf-8")).decode("utf-8")
+    wallet_deep_link = f"bcwallet://aries_proof-request?oob={response_b64}"
+
     # This is the payload to send to the template
     data = {
         "image_contents": image_contents,
@@ -139,6 +143,7 @@ async def get_authorize(request: Request, db: Database = Depends(get_db)):
         "pid": auth_session.id,
         "controller_host": controller_host,
         "challenge_poll_uri": ChallengePollUri,
+        "wallet_deep_link": wallet_deep_link,
     }
 
     # Prepare the template

--- a/oidc-controller/api/routers/oidc.py
+++ b/oidc-controller/api/routers/oidc.py
@@ -1,5 +1,6 @@
 import base64
 import io
+import json
 from typing import cast
 import uuid
 from datetime import datetime
@@ -18,6 +19,14 @@ from pyop.exceptions import InvalidAuthenticationRequest
 from ..authSessions.crud import AuthSessionCreate, AuthSessionCRUD
 from ..authSessions.models import AuthSessionPatch, AuthSessionState
 from ..core.acapy.client import AcapyClient
+from ..core.aries import (
+    OOBServiceDecorator,
+    OutOfBandMessage,
+    OutOfBandPresentProofAttachment,
+    PresentationRequestMessage,
+    PresentProofv10Attachment,
+    ServiceDecorator,
+)
 from ..core.config import settings
 from ..core.logger_util import log_debug
 from ..core.oidc import provider
@@ -105,18 +114,70 @@ async def get_authorize(request: Request, db: Database = Depends(get_db)):
 
     # Create presentation_request to show on screen
     response = client.create_presentation_request(ver_config.generate_proof_request())
+    pres_exch_dict = response.dict()
 
+    # Prepeare the presentation request    
+    client = AcapyClient()
+    use_public_did = (
+        not settings.USE_OOB_PRESENT_PROOF
+    ) and settings.USE_OOB_LOCAL_DID_SERVICE
+    wallet_did = client.get_wallet_did(public=use_public_did)
+
+    byo_attachment = PresentProofv10Attachment.build(
+        pres_exch_dict["presentation_request"]
+    )
+
+    msg = None
+    if settings.USE_OOB_PRESENT_PROOF:
+        if settings.USE_OOB_LOCAL_DID_SERVICE:
+            oob_s_d = OOBServiceDecorator(
+                service_endpoint=client.service_endpoint,
+                recipient_keys=[wallet_did.verkey],
+            ).dict()
+        else:
+            wallet_did = client.get_wallet_did(public=True)
+            oob_s_d = wallet_did.verkey
+
+        msg = PresentationRequestMessage(
+            id=pres_exch_dict["thread_id"],
+            request=[byo_attachment],
+        )
+        oob_msg = OutOfBandMessage(
+            request_attachments=[
+                OutOfBandPresentProofAttachment(
+                    id="request-0",
+                    data={"json": msg.dict(by_alias=True)},
+                )
+            ],
+            id=pres_exch_dict["thread_id"],
+            services=[oob_s_d],
+        )
+        msg_contents = oob_msg
+    else:
+        s_d = ServiceDecorator(
+            service_endpoint=client.service_endpoint, recipient_keys=[wallet_did.verkey]
+        )
+        msg = PresentationRequestMessage(
+            id=pres_exch_dict["thread_id"],
+            request=[byo_attachment],
+            service=s_d,
+        )
+        msg_contents = msg
+    
+    
+    # Create and save OIDC AuthSession 
     new_auth_session = AuthSessionCreate(
         response_url=authn_response.request(auth_req["redirect_uri"]),
         pyop_auth_code=authn_response["code"],
         request_parameters=model.to_dict(),
         ver_config_id=ver_config_id,
         pres_exch_id=response.presentation_exchange_id,
-        presentation_exchange=response.dict(),
+        presentation_exchange=pres_exch_dict,
+        presentation_request_msg=msg_contents.dict(by_alias=True),
     )
-
-    # save OIDC AuthSession
     auth_session = await AuthSessionCRUD(db).create(new_auth_session)
+
+    formated_msg = json.dumps(msg_contents.dict(by_alias=True))
 
     # QR CONTENTS
     controller_host = settings.CONTROLLER_URL
@@ -130,8 +191,10 @@ async def get_authorize(request: Request, db: Database = Depends(get_db)):
     callback_url = f"""{controller_host}{AuthorizeCallbackUri}?pid={auth_session.id}"""
 
     # BC Wallet deep link
-    response_b64 = base64.b64encode(response.json().encode("utf-8")).decode("utf-8")
-    wallet_deep_link = f"bcwallet://aries_proof-request?oob={response_b64}"
+    # base64 encode the formated_msg
+    base64_msg = base64.b64encode(formated_msg.encode("utf-8")).decode("utf-8")
+    wallet_deep_link = f"bcwallet://aries_proof-request?c_i={base64_msg}"
+
 
     # This is the payload to send to the template
     data = {

--- a/oidc-controller/api/templates/verified_credentials.html
+++ b/oidc-controller/api/templates/verified_credentials.html
@@ -154,6 +154,10 @@
         padding: 1rem 2rem 1rem 0.5rem;
         margin-left: 1.5rem;
       }
+      .header-desc.expired.expired-deep-link {
+        margin-left: 0;
+        width: 100%;
+      }
       .header-desc.pending svg {
         width: 2rem;
         height: 2rem;
@@ -167,6 +171,9 @@
       }
       .header-desc.expired {
         background-color: #f0f0f0;
+      }
+      .header-desc.expired-deep-link {
+        margin-bottom: 1.5rem;
       }
       .header-desc.failed {
         background-color: #f2dede;
@@ -209,6 +216,7 @@
         font-weight: 700;
         letter-spacing: 1px;
         cursor: pointer;
+        border-radius: 4px;
       }
       .BC-Gov-PrimaryButton:hover,
       .BC-Gov-SecondaryButton:hover {
@@ -223,7 +231,6 @@
       .BC-Gov-PrimaryButton {
         background-color: #003366;
         border: none;
-        border-radius: 4px;
         color: white;
         padding: 12px 32px;
         margin-bottom: 1.5rem;
@@ -233,7 +240,6 @@
       }
       .BC-Gov-SecondaryButton {
         background: none;
-        border-radius: 4px;
         border: 2px solid #003366;
         padding: 10px 30px;
         color: #003366;
@@ -245,6 +251,16 @@
       }
       .BC-Gov-SecondaryButton:active {
         opacity: 1;
+      }
+      .BC-Gov-PrimaryButton-disabled {
+        display: block;
+        background-color: #003366;
+        opacity: 0.3;
+        border: none;
+        color: white;
+        padding: 12px 32px;
+        cursor: not-allowed;
+        margin-bottom: 1.5rem;
       }
 
       /* Mobile device */
@@ -259,7 +275,19 @@
       <div class="content">
         <!-- BC Wallet deep link if the user agent is a mobile device -->
         <div class="mobile-device">
-          <h1>Scan with a Digital Wallet</h1>
+          <h1>Continue with:</h1>
+
+          <div class="header-desc expired expired-deep-link">
+            <div class="qr-code-image">{{add_asset("expired.svg")}}</div>
+            <div class="qr-code-desc">
+              <b>Proof has expired.</b>
+              </br>
+              <a href="javascript:window.location.reload(true)"
+              title="Refresh Link."
+                >Refresh Link.</a
+              >
+            </div>
+          </div>
 
           <a
           class="BC-Gov-PrimaryButton"
@@ -480,7 +508,7 @@
      */
     const setUiElements = (state, showRefresh, showScanned, setSpinner) => {
       console.log('Setting UI elements')
-      const stateElement = document.querySelector(state);
+      const stateElement = document.querySelectorAll(state);
       const qrcode = document.querySelector(".qr-code");
       const scannedMask = document.querySelector(".scanned-mask");
       const refreshButton = document.getElementById("refresh-button");
@@ -489,7 +517,16 @@
       document.querySelectorAll(".header-desc").forEach((el) => {
         el.style.display = "none";
       });
-      stateElement.style.display = "grid";
+      stateElement.forEach((el) => {
+        el.style.display = "grid";
+      });
+
+      // For expired state, set the deep link to disabed
+      if(state === ".expired") {
+        const deepLink = document.querySelector(".BC-Gov-PrimaryButton");
+        deepLink.classList.replace("BC-Gov-PrimaryButton", "BC-Gov-PrimaryButton-disabled");
+        deepLink.href = "";
+      }
 
       // set the refresh and/or scanned overlays
       refreshButton.style.display = showRefresh ? "flex" : "none";

--- a/oidc-controller/api/templates/verified_credentials.html
+++ b/oidc-controller/api/templates/verified_credentials.html
@@ -277,6 +277,13 @@
         <div class="mobile-device">
           <h1>Continue with:</h1>
 
+          <div class="header-desc success">
+            <div class="qr-code-image">{{add_asset("circle-check.svg")}}</div>
+            <div class="qr-code-desc">
+              <b>Success!</b> You will be redirected shortly.
+            </div>
+          </div>
+
           <div class="header-desc expired expired-deep-link">
             <div class="qr-code-image">{{add_asset("expired.svg")}}</div>
             <div class="qr-code-desc">
@@ -290,9 +297,10 @@
           </div>
 
           <a
-          class="BC-Gov-PrimaryButton"
+                    class="BC-Gov-PrimaryButton"
           title="Open BC Wallet"
           href="{{wallet_deep_link}}"
+          target="_blank"
           >
             BC Wallet
           </a>
@@ -462,7 +470,7 @@
     const socket = io(location.host, {
       path: "/ws/socket.io",
       autoConnect: false,
-    });
+          });
 
     socket.on("connect", () => {
       socket.emit('initialize', { pid: "{{pid}}" });
@@ -481,7 +489,7 @@
         case "verified":
           setUiElements(".success", false, true, false);
           setTimeout(() => {
-            window.location.replace("{{callback_url}}", { method: "POST" });
+          window.location.replace("{{callback_url}}", { method: "POST" });
           }, 2000);
           break;
         case "failed":
@@ -552,7 +560,7 @@
       fetch(url)
         .then((res) => res.json())
         .then((data) => {
-          /*
+                    /*
             Possible states:
             - not_started
             - pending

--- a/oidc-controller/api/templates/verified_credentials.html
+++ b/oidc-controller/api/templates/verified_credentials.html
@@ -322,7 +322,8 @@
 
         <!-- BC Wallet deep link if the user agent is a mobile device -->
         <div class="mobile-device">
-          <a class="BC-Gov-PrimaryButton" 
+          <a id="deep-link-button"
+              class="BC-Gov-PrimaryButton" 
               title="Open BC Wallet" 
               href="{{wallet_deep_link}}" 
               target="_blank">

--- a/oidc-controller/api/templates/verified_credentials.html
+++ b/oidc-controller/api/templates/verified_credentials.html
@@ -234,6 +234,7 @@
         color: white;
         padding: 12px 32px;
         margin-bottom: 1.5rem;
+        margin-top: 1.5rem;
       }
       .BC-Gov-PrimaryButton:active {
         opacity: 1;
@@ -261,6 +262,7 @@
         padding: 12px 32px;
         cursor: not-allowed;
         margin-bottom: 1.5rem;
+        margin-top: 1.5rem;
       }
 
       /* Mobile device */
@@ -273,43 +275,63 @@
     <div class="container">
       <div class="header-branding">{{add_asset("BCID_H_rgb_rev.svg")}}</div>
       <div class="content">
+  
+        <h1 class="desktop-device desktop-header">Scan with a Digital Wallet</h1>
+        <h1 class="mobile-device">Continue with:</h1>
+
+        <div class="header-desc success">
+          <div class="qr-code-image">{{add_asset("circle-check.svg")}}</div>
+          <div class="qr-code-desc">
+            <b>Success!</b> You will be redirected shortly.
+          </div>
+        </div>
+
+        <div class="header-desc failed">
+          <div class="qr-code-image">{{add_asset("circle-x.svg")}}</div>
+          <div class="qr-code-desc">
+            <b>Proof not accepted.</b>
+            </br>
+            <a href="javascript:window.location.reload(true)" title="Please try again.">Please try again.</a>
+          </div>
+        </div>
+        
+        <div class="header-desc expired">
+          <div class="qr-code-image">{{add_asset("expired.svg")}}</div>
+          <div class="qr-code-desc">
+            <b>Proof has expired.</b>
+            </br>
+            <a href="javascript:window.location.reload(true)" title="Refresh Proof.">Refresh Proof.</a>
+          </div>
+        </div>
+        
+        <div class="header-desc abandoned">
+          <div class="qr-code-image">{{add_asset("circle-x.svg")}}</div>
+          <div class="qr-code-desc">
+            <b>Proof declined</b>
+            </br>
+            <a href="javascript:window.location.reload(true)" title="Refresh QR code.">Try again.</a>
+          </div>
+        </div>
+        
+        <div class="header-desc pending">
+          <div class="qr-code-image">{{add_asset("hourglass.svg")}}</div>
+          <div class="qr-code-desc">
+            <b>Proof is pending.</b>
+          </div>
+        </div>
+
         <!-- BC Wallet deep link if the user agent is a mobile device -->
         <div class="mobile-device">
-          <h1>Continue with:</h1>
-
-          <div class="header-desc success">
-            <div class="qr-code-image">{{add_asset("circle-check.svg")}}</div>
-            <div class="qr-code-desc">
-              <b>Success!</b> You will be redirected shortly.
-            </div>
-          </div>
-
-          <div class="header-desc expired expired-deep-link">
-            <div class="qr-code-image">{{add_asset("expired.svg")}}</div>
-            <div class="qr-code-desc">
-              <b>Proof has expired.</b>
-              </br>
-              <a href="javascript:window.location.reload(true)"
-              title="Refresh Link."
-                >Refresh Link.</a
-              >
-            </div>
-          </div>
-
-          <a
-                    class="BC-Gov-PrimaryButton"
-          title="Open BC Wallet"
-          href="{{wallet_deep_link}}"
-          target="_blank"
-          >
+          <a class="BC-Gov-PrimaryButton" 
+              title="Open BC Wallet" 
+              href="{{wallet_deep_link}}" 
+              target="_blank">
             BC Wallet
           </a>
 
-          <a
-          id="other-device-button"
-          class="BC-Gov-SecondaryButton"
-          title="Open BC Wallet"
-          >
+          <a id="other-device-button" 
+              class="BC-Gov-SecondaryButton" 
+              title="Open BC Wallet">
             BC Wallet on other device
           </a>
 
@@ -325,63 +347,11 @@
 
         <!-- QR Code for desktop/other -->
         <div class="desktop-device">
-          <h1 class="desktop-header">Scan with a Digital Wallet</h1>
-
           <div class="header-desc intro">
             <div class="qr-code-image">{{add_asset("hand-qrcode.svg")}}</div>
             <div class="qr-code-desc">
               Scanning this QR code will send you a request to share your
               information
-            </div>
-          </div>
-
-          <div class="header-desc success">
-            <div class="qr-code-image">{{add_asset("circle-check.svg")}}</div>
-            <div class="qr-code-desc">
-              <b>Success!</b> You will be redirected shortly.
-            </div>
-          </div>
-
-        <div class="header-desc failed">
-            <div class="qr-code-image">{{add_asset("circle-x.svg")}}</div>
-            <div class="qr-code-desc">
-              <b>Proof not accepted.</b>
-              </br>
-              <a href="javascript:window.location.reload(true)"
-              title="Please try again."
-                >Please try again.</a
-              >
-            </div>
-          </div>
-
-        <div class="header-desc expired">
-            <div class="qr-code-image">{{add_asset("expired.svg")}}</div>
-            <div class="qr-code-desc">
-              <b>Proof has expired.</b>
-              </br>
-              <a href="javascript:window.location.reload(true)"
-              title="Refresh QR code."
-                >Refresh QR code.</a
-              >
-            </div>
-          </div>
-
-          <div class="header-desc abandoned">
-            <div class="qr-code-image">{{add_asset("circle-x.svg")}}</div>
-            <div class="qr-code-desc">
-              <b>Proof declined</b>
-              </br>
-              <a href="javascript:window.location.reload(true)"
-                title="Refresh QR code."
-                >Try again.</a
-              >
-            </div>
-          </div>
-
-          <div class="header-desc pending">
-            <div class="qr-code-image">{{add_asset("hourglass.svg")}}</div>
-            <div class="qr-code-desc">
-              <b>Proof is pending.</b>
             </div>
           </div>
 
@@ -529,8 +499,8 @@
         el.style.display = "grid";
       });
 
-      // For expired state, set the deep link to disabed
-      if(state === ".expired") {
+      // For expired or sucess state, set the deep link to disabed
+      if(state === ".expired" || state === ".success") {
         const deepLink = document.querySelector(".BC-Gov-PrimaryButton");
         deepLink.classList.replace("BC-Gov-PrimaryButton", "BC-Gov-PrimaryButton-disabled");
         deepLink.href = "";
@@ -589,8 +559,10 @@
      */
      document.querySelector("#other-device-button").addEventListener("click", () => {
       document.querySelector(".header-share").style.display = "none";
+      document.querySelectorAll(".desktop-device").forEach((el) => {
+        el.style.display = "block";
+      });
       document.querySelector(".desktop-header").style.display = "none";
-      document.querySelector(".desktop-device").style.display = "block";
      });
      
 

--- a/oidc-controller/api/templates/verified_credentials.html
+++ b/oidc-controller/api/templates/verified_credentials.html
@@ -16,6 +16,7 @@
       .container {
         text-align: center;
         border-radius: 0.5rem;
+        border:none;
         box-shadow: 2px 2px 3px 3px #dedede;
       }
       .content {
@@ -41,10 +42,19 @@
         width: 18rem;
         margin-left: 3rem;
       }
+      .header-share {
+        display: grid;
+        grid-template-columns: 5rem 1fr;
+        width: 22rem;
+        margin-top: 1.5rem;
+        margin-bottom: 1.75rem;
+      }
       .qr-code-desc {
         text-align: left;
       }
       .qr-code {
+        display: flex;
+        justify-content: center;
         position: relative;
         margin: 2rem 0 2rem -0.5rem;
       }
@@ -79,7 +89,7 @@
         background-color: white;
         height: 100%;
         width: 19rem;
-        margin-left: 2.8rem;
+        /* margin-left: 2.8rem; */
         align-items: center;
         justify-content: center;
         z-index: 1;
@@ -188,91 +198,177 @@
       .text-link label {
         display: block;
       }
+
+      /* BC Gov style buttons */
+      .BC-Gov-PrimaryButton,
+      .BC-Gov-SecondaryButton {
+        text-align: center;
+        text-decoration: none;
+        display: block;
+        font-size: 18px;
+        font-weight: 700;
+        letter-spacing: 1px;
+        cursor: pointer;
+      }
+      .BC-Gov-PrimaryButton:hover,
+      .BC-Gov-SecondaryButton:hover {
+        text-decoration: underline;
+        opacity: 0.80;
+      }
+      .BC-Gov-PrimaryButton:focus,
+      .BC-Gov-SecondaryButton:focus{
+        outline: 4px solid #3B99FC;
+        outline-offset: 1px;
+      }
+      .BC-Gov-PrimaryButton {
+        background-color: #003366;
+        border: none;
+        border-radius: 4px;
+        color: white;
+        padding: 12px 32px;
+        margin-bottom: 1.5rem;
+      }
+      .BC-Gov-PrimaryButton:active {
+        opacity: 1;
+      }
+      .BC-Gov-SecondaryButton {
+        background: none;
+        border-radius: 4px;
+        border: 2px solid #003366;
+        padding: 10px 30px;
+        color: #003366;
+        margin-bottom: 1.5rem;
+      }
+      .BC-Gov-SecondaryButton:hover {
+        background-color: #003366;
+        color: #FFFFFF;
+      }
+      .BC-Gov-SecondaryButton:active {
+        opacity: 1;
+      }
+
+      /* Mobile device */
+      .mobile-device{
+        display: none;
+      }
     </style>
   </head>
   <body>
     <div class="container">
       <div class="header-branding">{{add_asset("BCID_H_rgb_rev.svg")}}</div>
       <div class="content">
-        <h1>Scan with a Digital Wallet</h1>
+        <!-- BC Wallet deep link if the user agent is a mobile device -->
+        <div class="mobile-device">
+          <h1>Scan with a Digital Wallet</h1>
 
-        <div class="header-desc intro">
-          <div class="qr-code-image">{{add_asset("hand-qrcode.svg")}}</div>
-          <div class="qr-code-desc">
-            Scanning this QR code will send you a request to share your
-            information
-          </div>
-        </div>
+          <a
+          class="BC-Gov-PrimaryButton"
+          title="Open BC Wallet"
+          href="{{wallet_deep_link}}"
+          >
+            BC Wallet
+          </a>
 
-        <div class="header-desc success">
-          <div class="qr-code-image">{{add_asset("circle-check.svg")}}</div>
-          <div class="qr-code-desc">
-            <b>Success!</b> You will be redirected shortly.
-          </div>
-        </div>
+          <a
+          id="other-device-button"
+          class="BC-Gov-SecondaryButton"
+          title="Open BC Wallet"
+          >
+            BC Wallet on other device
+          </a>
 
-       <div class="header-desc failed">
-          <div class="qr-code-image">{{add_asset("circle-x.svg")}}</div>
-          <div class="qr-code-desc">
-            <b>Proof not accepted.</b>
-            </br>
-            <a href="javascript:window.location.reload(true)"
-             title="Please try again."
-              >Please try again.</a
-            >
-          </div>
-        </div>
-
-       <div class="header-desc expired">
-          <div class="qr-code-image">{{add_asset("expired.svg")}}</div>
-          <div class="qr-code-desc">
-            <b>Proof has expired.</b>
-            </br>
-            <a href="javascript:window.location.reload(true)"
-             title="Refresh QR code."
-              >Refresh QR code.</a
-            >
-          </div>
-        </div>
-
-        <div class="header-desc abandoned">
-           <div class="qr-code-image">{{add_asset("circle-x.svg")}}</div>
-           <div class="qr-code-desc">
-             <b>Proof declined</b>
-             </br>
-             <a href="javascript:window.location.reload(true)"
-              title="Refresh QR code."
-               >Try again.</a
-             >
-           </div>
-         </div>
-
-        <div class="header-desc pending">
-          <div class="qr-code-image">{{add_asset("hourglass.svg")}}</div>
-          <div class="qr-code-desc">
-            <b>Proof is pending.</b>
-          </div>
-        </div>
-
-        <div class="qr-code">
-          <button id="refresh-button" class="qr-button" title="Refresh QR Code">
-            <div class="button-content">
-              <div class="fake-button">
-                <div class="icon">{{add_asset("refresh.svg")}}</div>
-                <div class="description">Refresh QR code</div>
-              </div>
+          <div class="header-share">
+            <div class="qr-code-image">{{add_asset("hand-qrcode.svg")}}</div>
+            <div class="qr-code-desc">
+              A request to share your information will be sent to your
+              BC Wallet
             </div>
-          </button>
-          <div class="scanned-mask">
-            <div class="message">QR code scanned</div>
+            <hr>
           </div>
-          <div class="border">{{add_asset("dashed-border.svg")}}</div>
-          <img
-            src="data:image/jpeg;base64,{{image_contents}}"
-            alt="{{image_contents}}"
-            width="300px"
-            height="300px"
-          />
+        </div>
+
+        <!-- QR Code for desktop/other -->
+        <div class="desktop-device">
+          <h1 class="desktop-header">Scan with a Digital Wallet</h1>
+
+          <div class="header-desc intro">
+            <div class="qr-code-image">{{add_asset("hand-qrcode.svg")}}</div>
+            <div class="qr-code-desc">
+              Scanning this QR code will send you a request to share your
+              information
+            </div>
+          </div>
+
+          <div class="header-desc success">
+            <div class="qr-code-image">{{add_asset("circle-check.svg")}}</div>
+            <div class="qr-code-desc">
+              <b>Success!</b> You will be redirected shortly.
+            </div>
+          </div>
+
+        <div class="header-desc failed">
+            <div class="qr-code-image">{{add_asset("circle-x.svg")}}</div>
+            <div class="qr-code-desc">
+              <b>Proof not accepted.</b>
+              </br>
+              <a href="javascript:window.location.reload(true)"
+              title="Please try again."
+                >Please try again.</a
+              >
+            </div>
+          </div>
+
+        <div class="header-desc expired">
+            <div class="qr-code-image">{{add_asset("expired.svg")}}</div>
+            <div class="qr-code-desc">
+              <b>Proof has expired.</b>
+              </br>
+              <a href="javascript:window.location.reload(true)"
+              title="Refresh QR code."
+                >Refresh QR code.</a
+              >
+            </div>
+          </div>
+
+          <div class="header-desc abandoned">
+            <div class="qr-code-image">{{add_asset("circle-x.svg")}}</div>
+            <div class="qr-code-desc">
+              <b>Proof declined</b>
+              </br>
+              <a href="javascript:window.location.reload(true)"
+                title="Refresh QR code."
+                >Try again.</a
+              >
+            </div>
+          </div>
+
+          <div class="header-desc pending">
+            <div class="qr-code-image">{{add_asset("hourglass.svg")}}</div>
+            <div class="qr-code-desc">
+              <b>Proof is pending.</b>
+            </div>
+          </div>
+
+          <div class="qr-code">
+            <button id="refresh-button" class="qr-button" title="Refresh QR Code">
+              <div class="button-content">
+                <div class="fake-button">
+                  <div class="icon">{{add_asset("refresh.svg")}}</div>
+                  <div class="description">Refresh QR code</div>
+                </div>
+              </div>
+            </button>
+            <div class="scanned-mask">
+              <div class="message">QR code scanned</div>
+            </div>
+            <div class="border">{{add_asset("dashed-border.svg")}}</div>
+            <img
+              src="data:image/jpeg;base64,{{image_contents}}"
+              alt="{{image_contents}}"
+              width="300px"
+              height="300px"
+            />
+          </div>
         </div>
 
         <!-- Add a input box with the url_to_message data -->
@@ -286,21 +382,55 @@
           >{{url_to_message}}</textarea>
         </div>
 
-        <div>
+        <p>
           <b>Don't have a digital wallet?</b>
-        </div>
-        <a
-          title="Download BC Wallet"
-          href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-wallet"
-          >Download BC Wallet</a
-        >
+        </p>
+        <p>
+          <a
+            title="Download BC Wallet"
+            href="https://www2.gov.bc.ca/gov/content/governments/government-id/bc-wallet"
+            >Download the BC Wallet app
+          </a>
+        </p>
       </div>
     </div>
   </body>
   <script>
     /**
+     * Function to detect the user's browser
+     */
+    function getBrowser() {
+        var userAgent = navigator.userAgent || navigator.vendor;
+
+        if (/android/i.test(userAgent)) {
+            return "Android";
+        }
+
+        if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
+            return "iOS";
+        }
+
+        return "unknown";
+    }
+    function showHideElementForBrowser(elementId, show) {
+      if (getBrowser() === "Android" || getBrowser() === "iOS") {
+        var elements = document.querySelectorAll(elementId);
+        elements.forEach((el) => {
+          el.style.display = show ? "block" : "none";
+        });
+      }
+    }
+    try {
+    showHideElementForBrowser(".desktop-device", false);
+    showHideElementForBrowser(".mobile-device", true);
+    } catch (e) {
+      console.log("Error adding event listener to header branding", e);
+    }
+
+    /**
      * Initialize the Websocket
      */
+    console.log("init");
     const socket = io(location.host, {
       path: "/ws/socket.io",
       autoConnect: false,
@@ -315,6 +445,7 @@
     socket.connect();
 
     const toggleState = (state) => {
+      console.log('Toggling state', state)
       switch (state) {
         case "intro":
           setUiElements(".intro", false, false, false);
@@ -348,6 +479,7 @@
      * Set the UI elements based on the current state
      */
     const setUiElements = (state, showRefresh, showScanned, setSpinner) => {
+      console.log('Setting UI elements')
       const stateElement = document.querySelector(state);
       const qrcode = document.querySelector(".qr-code");
       const scannedMask = document.querySelector(".scanned-mask");
@@ -406,6 +538,16 @@
     timer = setInterval(() => {
       checkStatus();
     }, 2000);
+
+    /**
+     * If the other device button is clicked, show the qr code area
+     */
+     document.querySelector("#other-device-button").addEventListener("click", () => {
+      document.querySelector(".header-share").style.display = "none";
+      document.querySelector(".desktop-header").style.display = "none";
+      document.querySelector(".desktop-device").style.display = "block";
+     });
+     
 
     /**
      * If the BC_ID is clicked on 10 times in a row, display the link textbox


### PR DESCRIPTION
Add capability of displaying a deep link specific to the BC Wallet app. On devices that can have the app (iOS, Android) show the Deep link as the main option, with an ability to get a QR code as well.
See Kim's mockups here for UI/UX https://xd.adobe.com/view/b40869d2-5fff-40ff-855c-ace0d1da0c30-e15b/

Additionally, change the flow to generate the presentation request message contents when the controller loads (and creates the QR code and deep link), rather than waiting until the short QR link is called back to.
This message content is stored with the auth_session document in the mongo collection, so that it is _fetched_ instead of generated on that QR callback.