### PR TITLE
iPad desktop user agent detection

### DIFF
--- a/oidc-controller/api/templates/verified_credentials.html
+++ b/oidc-controller/api/templates/verified_credentials.html
@@ -413,8 +413,11 @@
             return "Android";
         }
 
-        if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
-            return "iOS";
+        if (/iPad|iPhone|iPod/.test(userAgent) || 
+          /Macintosh/.test(userAgent) && 'ontouchend' in document ||
+          (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1) ||
+          navigator.vendor && navigator.vendor.indexOf('Apple') > -1) {
+          return "iOS";
         }
 
         return "unknown";


### PR DESCRIPTION
The Deep Link user agent detection I had implemented was working on my iPad but I realized that was because I had the particular browser set to always Request Mobile.
This is actually not default behaviour on iPads after iOS 13 (it defaults to Request Desktop) so the typical user agent detection doesn't work and thinks it's a Mac.

Add feature-detection as well to handle this case. It's been a while since I've done one of these but something like this seems to be what the kids are using these days
```
        if (/iPad|iPhone|iPod/.test(userAgent) || 
          /Macintosh/.test(userAgent) && 'ontouchend' in document ||
          (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1) ||
          navigator.vendor && navigator.vendor.indexOf('Apple') > -1) {
          return "iOS";
        }
```

User agent + feature detection is never going to be guaranteed to be future-proofed. Generally when looking this stuff up the advise is "do responsive design if you can, don't go down this path" but for this case it's not design/layout that determines the deep linking (it should not show for small desktop windows), we actually do need to know device. So the maintainability cost would have potential to be higher. IE this `if` statement could need to be adjusted at some future point.

Some other options would be to import a script that does this detection but keeps up to date. But I don't really like that because in order for it to just work without a change, testing, and deployment you'd have to be reliant on a `latest` of something and you don't want to pull in some external script that's not versioned for a broken version or malicious takeover.

Anyways, this handles Android and iOS devices (iPad mobile and desktop sites) for the foreseeable time.