### PR TITLE
Added outputs to publish action for use in on_push_main

### DIFF
--- a/.github/workflows/on_push_main.yaml
+++ b/.github/workflows/on_push_main.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           helm upgrade --install vc-authn-oidc \
           -f https://raw.githubusercontent.com/bcgov/trust-over-ip-configurations/main/helm-values/vc-authn-oidc/dev.yaml \
-          --set image.tag="dev" \
+          --set image.tag=${{ needs.build.outputs.image_version }} \
           ./charts/vc-authn-oidc --wait
       - name: Restart Deployments
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,14 @@ on:
         description: "Optional - The branch, tag or SHA to checkout."
         required: false
         type: string
+    outputs:
+      image_tag:
+        description: "The tag used for this image"
+        value: ${{ jobs.values.outputs.image_tag }}
+      image_version:
+        description: "The tag used for this image"
+        value: ${{ jobs.values.outputs.image_version }}
+
   workflow_dispatch:
     inputs:
       tag:
@@ -98,6 +106,13 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           platforms: ${{ env.PLATFORMS }}
+
+      - name: Get Build Info
+        id: values
+        shell: bash
+        run: |
+          echo "image_tag=${{ fromJSON(steps.meta.outputs.json).tags[0] }}" >> $GITHUB_OUTPUT
+          echo "image_version=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}" >> $GITHUB_OUTPUT
 
       # Temp fix
       # https://github.com/docker/build-push-action/issues/252


### PR DESCRIPTION
This should resolve the remaining issue mentioned in #429

While this does expose the image version something I am concerned about is that the tag input is possibly not being used at all in https://github.com/bcgov/vc-authn-oidc/blob/use-dev-image-in-helm-command/.github/workflows/publish.yml

We  can see this in https://github.com/bcgov/vc-authn-oidc/actions/runs/8825653481/job/24230180441 Build VC-AuthN / Publish VC-AuthN Image as opposed to Build VC-AuthN / Publish VC-AuthN dev Image as you would expect based on this expression
https://github.com/bcgov/vc-authn-oidc/blob/use-dev-image-in-helm-command/.github/workflows/publish.yml#L2
