### PR TITLE
Update to mongo 7 on local Docker

### DIFF
--- a/demo/vue/app/frontend/package-lock.json
+++ b/demo/vue/app/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/eslint-parser": "^7.24.5",
+        "@babel/eslint-parser": "^7.24.6",
         "@bcgov/bc-sans": "^2.1.0",
         "@vue/eslint-config-prettier": "^9.0.0",
         "axios": "^1.7.2",
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.5.tgz",
-      "integrity": "sha512-gsUcqS/fPlgAw1kOtpss7uhY6E9SFFANQ6EFX5GTvzUwaV0+sGaZWk6xq22MOdeT9wfxyokW3ceCUvOiRtZciQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.24.6.tgz",
+      "integrity": "sha512-Q1BfQX42zXHx732PLW0w4+Y3wJjoZKEMaatFUEAmQ7Z+jCXxinzeqX9bvv2Q8xNPes/H6F0I23oGkcgjaItmLw==",
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
         "eslint-visitor-keys": "^2.1.0",

--- a/demo/vue/app/frontend/package.json
+++ b/demo/vue/app/frontend/package.json
@@ -17,7 +17,7 @@
     "reinstall": "npm run purge && npm install"
   },
   "dependencies": {
-    "@babel/eslint-parser": "^7.24.5",
+    "@babel/eslint-parser": "^7.24.6",
     "@bcgov/bc-sans": "^2.1.0",
     "@vue/eslint-config-prettier": "^9.0.0",
     "axios": "^1.7.2",

--- a/demo/vue/app/package-lock.json
+++ b/demo/vue/app/package-lock.json
@@ -31,7 +31,7 @@
         "eslint-config-recommended": "^4.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "jest": "^29.7.0",
-        "nodemon": "^3.1.0",
+        "nodemon": "^3.1.1",
         "supertest": "^7.0.0"
       }
     },
@@ -7942,9 +7942,9 @@
       "dev": true
     },
     "node_modules/nodemon": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.0.tgz",
-      "integrity": "sha512-xqlktYlDMCepBJd43ZQhjWwMw2obW/JRvkrLxq5RCNcuDDX1DbcPT+qT1IlIIdf+DhnWs90JpTMe+Y5KxOchvA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.1.tgz",
+      "integrity": "sha512-k43xGaDtaDIcufn0Fc6fTtsdKSkV/hQzoQFigNH//GaKta28yoKVYXCnV+KXRqfT/YzsFaQU9VdeEG+HEyxr6A==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.5.2",

--- a/demo/vue/app/package.json
+++ b/demo/vue/app/package.json
@@ -53,7 +53,7 @@
     "eslint-config-recommended": "^4.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "jest": "^29.7.0",
-    "nodemon": "^3.1.0",
+    "nodemon": "^3.1.1",
     "supertest": "^7.0.0"
   }
 }

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
       - vc_auth
 
   controller-db:
-    image: mongo:6.0
+    image: mongo:7.0
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${OIDC_CONTROLLER_DB_USER}
       - MONGO_INITDB_ROOT_PASSWORD=${OIDC_CONTROLLER_DB_USER_PWD}

--- a/oidc-controller/requirements-dev.txt
+++ b/oidc-controller/requirements-dev.txt
@@ -6,4 +6,4 @@ pytest-asyncio==0.23.7
 pytest-cov==5.0.0
 pytest==8.2.1
 requests-mock==1.12.1
-setuptools==69.5.1
+setuptools==70.0.0

--- a/oidc-controller/requirements.txt
+++ b/oidc-controller/requirements.txt
@@ -5,8 +5,8 @@ pymongo==4.7.2
 pyop==3.4.1
 python-multipart==0.0.9 # required by fastapi to serve/upload files
 qrcode[pil]==7.4.2
-structlog==24.1.0
-uvicorn[standard]==0.29.0
+structlog==24.2.0
+uvicorn[standard]==0.30.0
 python-socketio==5.11.2 # required to run websockets
 canonicaljson==2.0.0 # used to provide unique consistent user identifiers
 pydantic-settings==2.2.1


### PR DESCRIPTION
Use `mongo:7.0` tag in Docker Compose (tried locally with an existing setup).
Can merge in if we validate the bitnami update for Helm went all good.