### PR TITLE
Use production Vue

### DIFF
--- a/oidc-controller/api/templates/verified_credentials.html
+++ b/oidc-controller/api/templates/verified_credentials.html
@@ -291,7 +291,7 @@
       </div>
     </div>
 
-    <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+    <script src="https://unpkg.com/vue@3.4.27/dist/vue.global.prod.js"></script>
   </body>
 
   <!-- Components -->


### PR DESCRIPTION
The embedded vue CDN import is pulling `<script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>` which is the development un-minified Vue library.
This will log out a warning in the console:
```
You are running a development build of Vue.
Make sure to use the production build (*.prod.js) when deploying for production.
```

As well, the `vue@3/dist` link will actually get the latest release Vue it appears, leaving open to possible production runtime bugs if a newer Vue version alters something that changes behaviour on the page. So pin to a specific Vue version.

Change to `vue@3.4.27/dist/vue.global.prod.js` to use the (much smaller) prod minified file and pin to 3.4.27.