### PR TITLE
Fix Out-Of-Band invitation option for QR codes

### DIFF
--- a/oidc-controller/api/core/acapy/client.py
+++ b/oidc-controller/api/core/acapy/client.py
@@ -7,7 +7,7 @@ import structlog
 
 from ..config import settings
 from .config import AgentConfig, MultiTenantAcapy, SingleTenantAcapy
-from .models import CreatePresentationResponse, WalletDid
+from .models import CreatePresentationResponse, OobCreateInvitationResponse, WalletDid
 
 _client = None
 logger = structlog.getLogger(__name__)
@@ -16,6 +16,7 @@ WALLET_DID_URI = "/wallet/did"
 PUBLIC_WALLET_DID_URI = "/wallet/did/public"
 CREATE_PRESENTATION_REQUEST_URL = "/present-proof/create-request"
 PRESENT_PROOF_RECORDS = "/present-proof/records"
+OOB_CREATE_INVITATION = "/out-of-band/create-invitation"
 
 
 class AcapyClient:
@@ -125,3 +126,32 @@ class AcapyClient:
 
         logger.debug(f"<<< get_wallet_did -> {did}")
         return did
+
+    def oob_create_invitation(
+        self, presentation_exchange: dict, use_public_did: bool
+    ) -> OobCreateInvitationResponse:
+        logger.debug(">>> oob_create_invitation")
+        create_invitation_payload = {
+            "attachments": [
+                {
+                    "id": presentation_exchange["presentation_exchange_id"],
+                    "type": "present-proof",
+                    "data": {"json": presentation_exchange},
+                }
+            ],
+            "use_public_did": use_public_did,
+        }
+
+        resp_raw = requests.post(
+            self.acapy_host + OOB_CREATE_INVITATION,
+            headers=self.agent_config.get_headers(),
+            json=create_invitation_payload,
+        )
+
+        assert resp_raw.status_code == 200, resp_raw.content
+
+        resp = json.loads(resp_raw.content)
+        result = OobCreateInvitationResponse.parse_obj(resp)
+
+        logger.debug("<<< oob_create_invitation")
+        return result

--- a/oidc-controller/api/core/acapy/models.py
+++ b/oidc-controller/api/core/acapy/models.py
@@ -1,4 +1,5 @@
 from typing import Optional, Dict
+from ..aries import OutOfBandMessage
 
 from pydantic import BaseModel
 
@@ -17,3 +18,12 @@ class CreatePresentationResponse(BaseModel):
     thread_id: str
     presentation_exchange_id: str
     presentation_request: Dict
+
+
+class OobCreateInvitationResponse(BaseModel):
+    invi_msg_id: str
+    invitation_url: str
+    oob_id: str
+    trace: bool
+    state: str
+    invitation: OutOfBandMessage

--- a/oidc-controller/api/core/aries/service_decorator.py
+++ b/oidc-controller/api/core/aries/service_decorator.py
@@ -13,9 +13,9 @@ class ServiceDecorator(BaseModel):
 
 class OOBServiceDecorator(ServiceDecorator):
     # ServiceDecorator
-    recipient_keys: Optional[List[str]] = None
-    routing_keys: Optional[List[str]] = Field(default=[])
-    service_endpoint: Optional[str] = None
+    recipient_keys: Optional[List[str]] = Field(default=None, alias="recipientKeys")
+    routing_keys: Optional[List[str]] = Field(default=None, alias="routingKeys")
+    service_endpoint: Optional[str] = Field(default=None, alias="serviceEndpoint")
     id: str = Field(default="did:vc-authn-oidc:123456789zyxwvutsr#did-communication")
     type: str = Field(default="did-communication")
     priority: int = 0


### PR DESCRIPTION
Fixes https://github.com/bcgov/vc-authn-oidc/issues/545

Instead of building up a OOB invitation with code in VCAuth controller (this was not working, error boiled down to recipient keys not being added), call ACA-Py to use `out-of-band/create-invitation` with the resultant presentation exchange.
Use the invitation returned from that as the QR code linked payload.

**Note** this should only be used in QR code mode at the moment (which is what we configure in all envs for `USE_OOB_PRESENT_PROOF`) as doing it as a deep link runs into the 'too many characters' issue. A OOB is bigger than a Connections type so there's not really room for the actual proof unless it's narrowed to something as minimal as it gets.
This will be solved by https://github.com/bcgov/vc-authn-oidc/issues/504 anyways, so we won't be using the current deep link paradigm much longer anyways.

**Sample payload**
```
{
    "@id": "3d2fca0b-39d1-4580-8744-cecb7a155bf3",
    "@type": "https://didcomm.org/out-of-band/1.1/invitation",
    "goal_code": "request-proof",
    "label": "VC-AuthN Agent",
    "requests~attach": [
        {
            "@id": "request-0",
            "mime-type": "application/json",
            "data": {
                "json": {
                    "@type": "https://didcomm.org/present-proof/1.0/request-presentation",
                    "@id": "a6f0d822-9ae0-4408-b324-2ac1cbe95b1a",
                    "~thread": {
                        "pthid": "3d2fca0b-39d1-4580-8744-cecb7a155bf3"
                    },
                    "request_presentations~attach": [
                        {
                            "@id": "libindy-request-presentation-0",
                            "mime-type": "application/json",
                            "data": {
                                "base64": "eyJuYW1lIjogInByb29mX3JlcXVlc3RlZCIsICJ2ZXJzaW9uIjogIjAuMC4xIiwgInJlcXVlc3RlZF9hdHRyaWJ1dGVzIjogeyJyZXFfYXR0cl8wIjogeyJuYW1lcyI6IFsiZ2l2ZW5fbmFtZXMiLCAiZmFtaWx5X25hbWUiLCAiY291bnRyeSJdLCAicmVzdHJpY3Rpb25zIjogW3sic2NoZW1hX25hbWUiOiAiUGVyc29uIiwgImlzc3Vlcl9kaWQiOiAiTDZBU2ptRERiREg3eVBMMXQyeUZqOSJ9LCB7InNjaGVtYV9uYW1lIjogIlBlcnNvbiIsICJpc3N1ZXJfZGlkIjogIlFFcXVBSGtNMzV3NFhWVDNLdTV5YXQifSwgeyJzY2hlbWFfbmFtZSI6ICJQZXJzb24iLCAiaXNzdWVyX2RpZCI6ICJNNmRodUZqNVV3YmhXa1NMbXZZU1BjIn1dLCAibm9uX3Jldm9rZWQiOiB7ImZyb20iOiAxNzE4NzQwMzE0LCAidG8iOiAxNzE4NzQwMzE0fX19LCAicmVxdWVzdGVkX3ByZWRpY2F0ZXMiOiB7fSwgIm5vbmNlIjogIjExMTYxNzY0NDU2MDk1NTE4Mzc1NzUwMjAifQ=="
                            }
                        }
                    ]
                }
            }
        }
    ],
    "services": [
        {
            "recipientKeys": [
                "did:key:z6MkiyHJfTKAYHypgzVHAPzKxjw8Nknxsk8LNbP59zdikvPZ#z6MkiyHJfTKAYHypgzVHAPzKxjw8Nknxsk8LNbP59zdikvPZ"
            ],
            "routingKeys": null,
            "serviceEndpoint": "https://88db-23-16-82-223.ngrok-free.app",
            "id": "#inline",
            "type": "did-communication",
            "priority": 0
        }
    ]
}
```