### PR TITLE
Fix auth session Created At timestamp

### DIFF
--- a/oidc-controller/api/authSessions/models.py
+++ b/oidc-controller/api/authSessions/models.py
@@ -30,7 +30,7 @@ class AuthSessionBase(BaseModel):
     response_url: str
     presentation_request_msg: Optional[dict] = None
     model_config = ConfigDict(populate_by_name=True)
-    created_at: datetime = Field(default=datetime.now())
+    created_at: datetime = Field(default_factory=datetime.utcnow)
 
 
 class AuthSession(AuthSessionBase, UUIDModel):


### PR DESCRIPTION
See https://github.com/bcgov/vc-authn-oidc/issues/558

Use a factory fxn for default like other created at fields in the controller do. 