### PR TITLE
Use hash for sub

### DIFF
--- a/oidc-controller/api/core/oidc/issue_token_service.py
+++ b/oidc-controller/api/core/oidc/issue_token_service.py
@@ -1,6 +1,7 @@
 import canonicaljson
 import dataclasses
 import json
+import hashlib
 from datetime import datetime
 from typing import Any, Dict, List
 
@@ -98,12 +99,13 @@ class Token(BaseModel):
         elif ver_config.generate_consistent_identifier:
             # Do not create a sub based on the proof claims if the
             # user requests a generated identifier
+            # Generate a SHA256 hash of the canonicaljson encoded proof_claims
+            encoded_json = canonicaljson.encode_canonical_json(proof_claims)
+            sha256_hash = hashlib.sha256(encoded_json).hexdigest()
             oidc_claims.append(
                 Claim(
                     type="sub",
-                    value=canonicaljson.encode_canonical_json(proof_claims).decode(
-                        "utf-8"
-                    ),
+                    value=sha256_hash,
                 )
             )
 


### PR DESCRIPTION
See https://github.com/bcgov/vc-authn-oidc/issues/561 for details

Create the canonicaljson bytes the same as before but hash that with sha256 for a fixed 64 chars

At the point where the token is gotten from:
![image](https://github.com/bcgov/vc-authn-oidc/assets/17445138/6c2efcbf-aa64-47f2-b885-28b32849868d)

Now get a sub that looks like this:
![image](https://github.com/bcgov/vc-authn-oidc/assets/17445138/620b6f51-ca55-4bc6-8533-3926e555fd17)

