### PR TITLE
fix: add handshake_protocols to oob invitation

### DIFF
--- a/oidc-controller/api/core/aries/out_of_band.py
+++ b/oidc-controller/api/core/aries/out_of_band.py
@@ -26,5 +26,6 @@ class OutOfBandMessage(BaseModel):
         alias="requests~attach"
     )
     services: List[Union[OOBServiceDecorator, str]] = Field(alias="services")
+    handshake_protocols: List[str] = Field(alias="handshake_protocols", default=None)
 
     model_config = ConfigDict(populate_by_name=True)


### PR DESCRIPTION
I noticed that `handshake_protocols` field is gone when ACA-Py client parses the response. Usually it is not used in BCGov main use-case but I'm trying to use it in a case where I want to use a public DID and re-use any connection with the service.