### PR TITLE
fix: use url-safe b64 encoding in deep links

### DIFF
--- a/oidc-controller/api/routers/oidc.py
+++ b/oidc-controller/api/routers/oidc.py
@@ -164,10 +164,14 @@ async def get_authorize(request: Request, db: Database = Depends(get_db)):
     # BC Wallet deep link
     if settings.USE_URL_DEEP_LINK:
         suffix = (
-            f'_url={base64.urlsafe_b64encode(url_to_message.encode("utf-8")).decode("utf-8")}'
+            f'_url={base64.urlsafe_b64encode(
+                url_to_message.encode("utf-8")).decode("utf-8")}'
         )
     else:
-        suffix = f'c_i={base64.urlsafe_b64encode(formated_msg.encode("utf-8")).decode("utf-8")}'
+        suffix = (
+            f'c_i={base64.urlsafe_b64encode(
+                formated_msg.encode("utf-8")).decode("utf-8")}'
+        )
     WALLET_DEEP_LINK_PREFIX = settings.WALLET_DEEP_LINK_PREFIX
     wallet_deep_link = f"{WALLET_DEEP_LINK_PREFIX}?{suffix}"
 

--- a/oidc-controller/api/routers/oidc.py
+++ b/oidc-controller/api/routers/oidc.py
@@ -164,13 +164,13 @@ async def get_authorize(request: Request, db: Database = Depends(get_db)):
     # BC Wallet deep link
     if settings.USE_URL_DEEP_LINK:
         suffix = (
-            f'_url={base64.urlsafe_b64encode(
-                url_to_message.encode("utf-8")).decode("utf-8")}'
+            f"""_url={base64.urlsafe_b64encode(
+                url_to_message.encode("utf-8")).decode("utf-8")}"""
         )
     else:
         suffix = (
-            f'c_i={base64.urlsafe_b64encode(
-                formated_msg.encode("utf-8")).decode("utf-8")}'
+            f"""c_i={base64.urlsafe_b64encode(
+                formated_msg.encode("utf-8")).decode("utf-8")}"""
         )
     WALLET_DEEP_LINK_PREFIX = settings.WALLET_DEEP_LINK_PREFIX
     wallet_deep_link = f"{WALLET_DEEP_LINK_PREFIX}?{suffix}"

--- a/oidc-controller/api/routers/oidc.py
+++ b/oidc-controller/api/routers/oidc.py
@@ -164,10 +164,10 @@ async def get_authorize(request: Request, db: Database = Depends(get_db)):
     # BC Wallet deep link
     if settings.USE_URL_DEEP_LINK:
         suffix = (
-            f'_url={base64.b64encode(url_to_message.encode("utf-8")).decode("utf-8")}'
+            f'_url={base64.urlsafe_b64encode(url_to_message.encode("utf-8")).decode("utf-8")}'
         )
     else:
-        suffix = f'c_i={base64.b64encode(formated_msg.encode("utf-8")).decode("utf-8")}'
+        suffix = f'c_i={base64.urlsafe_b64encode(formated_msg.encode("utf-8")).decode("utf-8")}'
     WALLET_DEEP_LINK_PREFIX = settings.WALLET_DEEP_LINK_PREFIX
     wallet_deep_link = f"{WALLET_DEEP_LINK_PREFIX}?{suffix}"
 


### PR DESCRIPTION
I'm not sure if it already works well in your BC Wallet, but in our app we are using Credo to parse the DIDComm out-of-band invitation and it was failing, since it expects to have only base64url characters. This comes from [Aries RFC 0268](https://github.com/hyperledger/aries-rfcs/blob/main/concepts/0268-unified-didcomm-agent-deeplinking/README.md#tutorial), which talks about "base64url-encoded invitation". This Base 64 encoding with an URL and filename safe alphabet is defined in https://datatracker.ietf.org/doc/html/rfc4648#section-5.

So I fixed it by simply using `urlsafe_b64encode` instead of regular `b64encode` for _url or c_i parameter.

I didn't test it in BC Wallet, but if it is using Credo as well I don't see why it wouldn't work :thinking: .