### PR TITLE
Remove handshake protocols again temporarily

### DIFF
--- a/oidc-controller/api/core/aries/out_of_band.py
+++ b/oidc-controller/api/core/aries/out_of_band.py
@@ -26,6 +26,7 @@ class OutOfBandMessage(BaseModel):
         alias="requests~attach"
     )
     services: List[Union[OOBServiceDecorator, str]] = Field(alias="services")
-    handshake_protocols: List[str] = Field(alias="handshake_protocols", default=None)
+    # TODO: This is causing problems in our BC Wallet use case, TBD
+    # handshake_protocols: List[str] = Field(alias="handshake_protocols", default=None)
 
     model_config = ConfigDict(populate_by_name=True)


### PR DESCRIPTION
The OOB proof pydantic model was missing handshake_protocols so that was never getting outputted in the OOB message. Even though aca-py was returning it with `[]` in there.

https://github.com/bcgov/vc-authn-oidc/pull/577 addressed this so it could be used in the event a VCAuth operator does want something in there.

Could have sworn I tried it out a bunch with BC Wallet after that but I must have misconfigured something because now if I turn on OOB I get an error when scanning in BC Wallet
![image](https://github.com/user-attachments/assets/06ea4d42-466d-45c3-a88e-0b5397ad3bfd)


If I set didcomm or connections in the handshake protocols then the wallet seems to spin on the connecting screen.
So something is either wrong in the Wallet or our OOB message setup when including handshake protocols and going back to the old situation where it is just missing from the output works.

Trying to troubleshoot other OOB issues in BC Wallet so one thing at a time and going to eliminate this error from the current situation.