### PR TITLE
[Workflow FIx] Trigger e79518-dev-vc-authn-oidc instead of test

### DIFF
--- a/.github/workflows/on_push_main.yaml
+++ b/.github/workflows/on_push_main.yaml
@@ -101,7 +101,7 @@ jobs:
           address: gitops-shared.apps.silver.devops.gov.bc.ca
           token: ${{ secrets.DITP_GITOPS_ARGO_SECRET}}
           action: sync
-          appName: "e79518-test-vc-authn-oidc"
+          appName: "e79518-dev-vc-authn-oidc
 
   # Build vc-authn
   deploy_dev:

--- a/.github/workflows/on_push_main.yaml
+++ b/.github/workflows/on_push_main.yaml
@@ -101,7 +101,7 @@ jobs:
           address: gitops-shared.apps.silver.devops.gov.bc.ca
           token: ${{ secrets.DITP_GITOPS_ARGO_SECRET}}
           action: sync
-          appName: "e79518-dev-vc-authn-oidc
+          appName: "e79518-dev-vc-authn-oidc"
 
   # Build vc-authn
   deploy_dev:


### PR DESCRIPTION
Update workflow to trigger ArgoCD sync of `e79518-dev-vc-authn-oidc` instead of `e79518-test-vc-authn-oidc`