### PR TITLE
Bump ACA-Py to 1.0.0rc5 in chart values

### DIFF
--- a/charts/vc-authn-oidc/values.yaml
+++ b/charts/vc-authn-oidc/values.yaml
@@ -217,7 +217,7 @@ acapy:
     repository: ghcr.io/hyperledger/aries-cloudagent-python
     pullPolicy: IfNotPresent
     pullSecrets: []
-    tag: py3.9-0.12.1
+    tag: py3.12-1.0.0rc5
 
   ## ServiceAccount configuration
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -367,7 +367,7 @@ acapy:
     secretKeys:
       adminPasswordKey: admin-password
       userPasswordKey: database-password
-  
+
   ## @section Acapy tails persistence configuration
   persistence:
     ## @param acapy.persistence.existingClaim Name of an existing PVC to use


### PR DESCRIPTION
Need ACA-Py 1.0.0 to be able to use present-proof 2.0.

[This fix](https://github.com/hyperledger/aries-cloudagent-python/pull/3081) in particular is required, a mismatched version of the agent will cause the controller to throw an error.