### PR TITLE
Always deploy dev environment from main

### DIFF
--- a/.github/workflows/on_push_main.yaml
+++ b/.github/workflows/on_push_main.yaml
@@ -14,95 +14,6 @@ jobs:
       ref: "main"
       platforms: "linux/amd64"
 
-  check_helm_changes:
-    runs-on: ubuntu-latest
-    name: Check for Helm Chart changes
-    outputs:
-      helm_changed: ${{ steps.list-changed.outputs.changed }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Check for chart changes
-        id: list-changed
-        run: |
-          if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -q "^charts/"; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  update_configs_repo:
-    runs-on: ubuntu-latest
-    name: Update Configurations Repo
-    needs:
-      - build
-      - check_helm_changes
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Checkout services directory from the trust-over-ip-configurations repo
-        uses: actions/checkout@v4
-        with:
-          repository: bcgov/trust-over-ip-configurations
-          ssh-key: ${{ secrets.DITP_CONFIGS_REPO_SECRET }}
-          sparse-checkout: |
-            services
-          path: trust-over-ip-configurations
-
-      - name: Lookup Helm Chart and App versions
-        id: chart_version
-        run: |
-          helm repo add vc-authn-oidc https://bcgov.github.io/vc-authn-oidc
-          helm repo update
-          if [[ "${{ needs.check_helm_changes.outputs.helm_changed }}" == "true" ]]; then
-            echo "APP_VERSION=$(yq e .appVersion charts/vc-authn-oidc/Chart.yaml)" >> $GITHUB_OUTPUT
-            echo "CHART_VERSION=$(yq e .version charts/vc-authn-oidc/Chart.yaml)" >> $GITHUB_OUTPUT
-          else
-            echo "APP_VERSION=$(helm search repo vc-authn-oidc -ojson | jq -r '.[0].app_version')" >> $GITHUB_OUTPUT
-            echo "CHART_VERSION=$(helm search repo vc-authn-oidc -ojson | jq -r '.[0].version')" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Update versions
-        env:
-          APP_VERSION: ${{ steps.chart_version.outputs.APP_VERSION }}
-          CHART_VERSION: ${{ steps.chart_version.outputs.CHART_VERSION }}
-          IMAGE_TAG: ${{ needs.build.outputs.image_version }}
-        run: |
-          cd trust-over-ip-configurations
-
-          yq e -i '.appVersion = env(APP_VERSION)' services/vc-authn-oidc/charts/dev/Chart.yaml
-          yq e -i '.version = env(CHART_VERSION)' services/vc-authn-oidc/charts/dev/Chart.yaml
-          yq e -i '.dependencies[0].version = env(CHART_VERSION)' services/vc-authn-oidc/charts/dev/Chart.yaml
-          yq e -i '.vc-authn-oidc.image.tag = env(IMAGE_TAG)' services/vc-authn-oidc/charts/dev/values.yaml
-
-      - name: Commit and Push to trust-over-ip-configurations Repo
-        run: |
-          cd trust-over-ip-configurations
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add services/vc-authn-oidc/charts/dev/values.yaml services/vc-authn-oidc/charts/dev/Chart.yaml
-          git commit -m "Update chart version and image tag" || echo "No changes to commit"
-          git push origin main
-
-      - uses: convictional/trigger-workflow-and-wait@v1.6.5
-        id: workflow-trigger
-        with:
-          owner: bcgov
-          repo: trust-over-ip-configurations
-          github_token: ${{ secrets.DITP_CONFIGS_REPO_TOKEN }}
-          workflow_file_name: gitops_sync.yaml
-
-      - name: Trigger ArgoCD Sync of e79518-test-vc-authn-oidc
-        uses: OpsVerseIO/argocd-sync@0.2.0
-        if: needs.check_helm_changes.outputs.helm_changed != 'true' && steps.workflow-trigger.outputs.conclusion == 'success'
-        with:
-          address: gitops-shared.apps.silver.devops.gov.bc.ca
-          token: ${{ secrets.DITP_GITOPS_ARGO_SECRET}}
-          action: sync
-          appName: "e79518-dev-vc-authn-oidc"
-
   # Build vc-authn
   deploy_dev:
     name: Deploy VC-AuthN to Dev
@@ -110,8 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-      - check_helm_changes
-    if: ${{ needs.check_helm_changes.outputs.helm_changed == 'true' && contains(needs.*.result, 'success') && !(contains(needs.*.result, 'failure')) && (github.repository_owner == 'bcgov') }}
+    if: ${{ contains(needs.*.result, 'success') && !(contains(needs.*.result, 'failure')) && (github.repository_owner == 'bcgov') }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Always deploy `dev` using chart in `main` branch. We will need to disable ArgoCD for `dev` to avoid issues with synchronization.