### PR TITLE
Use Int representations for YYYYMMDD replacement values

### DIFF
--- a/oidc-controller/api/verificationConfigs/helpers.py
+++ b/oidc-controller/api/verificationConfigs/helpers.py
@@ -27,7 +27,7 @@ def replace_proof_variables(proof_req_dict: dict) -> dict:
         # If the value is a dictionary, recurse
         if isinstance(v, dict):
             replace_proof_variables(v)
-        # If the value is a list, iterate trhough list items and recurse
+        # If the value is a list, iterate through list items and recurse
         elif isinstance(v, list):
             for i in v:
                 if isinstance(i, dict):

--- a/oidc-controller/api/verificationConfigs/models.py
+++ b/oidc-controller/api/verificationConfigs/models.py
@@ -1,5 +1,5 @@
 import time
-from typing import Optional, List
+from typing import Optional, List, Union
 from pydantic import BaseModel, ConfigDict, Field
 
 from .examples import ex_ver_config
@@ -27,7 +27,7 @@ class ReqPred(BaseModel):
     name: str
     label: Optional[str] = None
     restrictions: List[AttributeFilter]
-    p_value: str
+    p_value: Union[int, str]
     p_type: str
 
 

--- a/oidc-controller/api/verificationConfigs/tests/test_variable_substitutions.py
+++ b/oidc-controller/api/verificationConfigs/tests/test_variable_substitutions.py
@@ -11,13 +11,13 @@ def test_get_now():
 
 def test_get_today_date():
     vsm = VariableSubstitutionMap()
-    assert vsm.get_today_date() == datetime.today().strftime("%Y%m%d")
+    assert vsm.get_today_date() == int(datetime.today().strftime("%Y%m%d"))
 
 
 def test_get_tomorrow_date():
     vsm = VariableSubstitutionMap()
-    assert vsm.get_tomorrow_date() == (datetime.today() + timedelta(days=1)).strftime(
-        "%Y%m%d"
+    assert vsm.get_tomorrow_date() == int(
+        (datetime.today() + timedelta(days=1)).strftime("%Y%m%d")
     )
 
 
@@ -33,8 +33,8 @@ def test_get_threshold_years_date():
 def test_contains_static_variable():
     vsm = VariableSubstitutionMap()
     assert "$now" in vsm
-    assert "$today_str" in vsm
-    assert "$tomorrow_str" in vsm
+    assert "$today_int" in vsm
+    assert "$tomorrow_int" in vsm
 
 
 def test_contains_dynamic_variable():
@@ -45,8 +45,8 @@ def test_contains_dynamic_variable():
 def test_getitem_static_variable():
     vsm = VariableSubstitutionMap()
     assert callable(vsm["$now"])
-    assert callable(vsm["$today_str"])
-    assert callable(vsm["$tomorrow_str"])
+    assert callable(vsm["$today_int"])
+    assert callable(vsm["$tomorrow_int"])
 
 
 def test_getitem_dynamic_variable():

--- a/oidc-controller/api/verificationConfigs/variableSubstitutions.py
+++ b/oidc-controller/api/verificationConfigs/variableSubstitutions.py
@@ -16,8 +16,8 @@ class VariableSubstitutionMap:
         # This class defines threshold_years_X as a dynamic one
         self.static_map = {
             "$now": self.get_now,
-            "$today_str": self.get_today_date,
-            "$tomorrow_str": self.get_tomorrow_date,
+            "$today_int": self.get_today_date,
+            "$tomorrow_int": self.get_tomorrow_date,
         }
 
     def get_threshold_years_date(self, years: int) -> int:
@@ -42,23 +42,23 @@ class VariableSubstitutionMap:
         """
         return int(time.time())
 
-    def get_today_date(self) -> str:
+    def get_today_date(self) -> int:
         """
-        Get today's date in YYYYMMDD format.
+        Get today's date in YYYYMMDD format as a number.
 
         Returns:
-            str: Today's date in YYYYMMDD format.
+            int: Today's date in YYYYMMDD format.
         """
-        return datetime.today().strftime("%Y%m%d")
+        return int(datetime.today().strftime("%Y%m%d"))
 
-    def get_tomorrow_date(self) -> str:
+    def get_tomorrow_date(self) -> int:
         """
-        Get tomorrow's date in YYYYMMDD format.
+        Get tomorrow's date in YYYYMMDD format as a number.
 
         Returns:
-            str: Tomorrow's date in YYYYMMDD format.
+            int: Tomorrow's date in YYYYMMDD format.
         """
-        return (datetime.today() + timedelta(days=1)).strftime("%Y%m%d")
+        return int((datetime.today() + timedelta(days=1)).strftime("%Y%m%d"))
 
     # For "dynamic" variables, use a regex to match the key and return a lambda function
     # So a proof request can use $threshold_years_X to get the years back for X years


### PR DESCRIPTION
Was keeping the p_values as strings for variables subs (IE `"20240101"`), should be integers instead

Also change model type to allow strings and ints, so if we need a config with a p_type of "$now" etc, or also support a hard coded int (like 20250101 or some other constant numerical value or something)