### PR TITLE
Add back handshake protocols

### DIFF
--- a/oidc-controller/api/core/aries/out_of_band.py
+++ b/oidc-controller/api/core/aries/out_of_band.py
@@ -26,7 +26,6 @@ class OutOfBandMessage(BaseModel):
         alias="requests~attach"
     )
     services: List[Union[OOBServiceDecorator, str]] = Field(alias="services")
-    # TODO: This is causing problems in our BC Wallet use case, TBD
-    # handshake_protocols: List[str] = Field(alias="handshake_protocols", default=None)
+    handshake_protocols: List[str] = Field(alias="handshake_protocols", default=None)
 
     model_config = ConfigDict(populate_by_name=True)


### PR DESCRIPTION
Add back in the handshake protocols field in the model for OOB invitations. See details here https://github.com/bcgov/vc-authn-oidc/issues/583

BC Wallet has released a while back with the Credo version that handles this now.

We provide a blank array in default setup for VCAuth at this time:

![image](https://github.com/user-attachments/assets/c8955073-cb3a-471c-855d-6cf497418c49)


