### PR TITLE
Append @pres_req_conf_id to sub

### DIFF
--- a/oidc-controller/api/core/oidc/issue_token_service.py
+++ b/oidc-controller/api/core/oidc/issue_token_service.py
@@ -110,8 +110,13 @@ class Token(BaseModel):
             # Do not create a sub based on the proof claims if the
             # user requests a generated identifier
             # Generate a SHA256 hash of the canonicaljson encoded proof_claims
-            encoded_json = canonicaljson.encode_canonical_json(proof_claims)
-            sha256_hash = hashlib.sha256(encoded_json).hexdigest()
+            encoded_json: bytes = canonicaljson.encode_canonical_json(proof_claims)
+            sha256_hash = hashlib.sha256(
+                (
+                    encoded_json
+                    + f"@{auth_session.request_parameters['pres_req_conf_id']}".encode()
+                )
+            ).hexdigest()
             oidc_claims.append(
                 Claim(
                     type="sub",

--- a/oidc-controller/api/core/oidc/issue_token_service.py
+++ b/oidc-controller/api/core/oidc/issue_token_service.py
@@ -98,7 +98,14 @@ class Token(BaseModel):
 
         if sub_id_claim:
             # add sub and append presentation_claims
-            oidc_claims.append(Claim(type="sub", value=sub_id_claim.value))
+            assert type(auth_session.request_parameters["pres_req_conf_id"]) == str
+            oidc_claims.append(
+                Claim(
+                    type="sub",
+                    value=f"{sub_id_claim.value}@{auth_session.request_parameters['pres_req_conf_id']}",
+                )
+            )
+
         elif ver_config.generate_consistent_identifier:
             # Do not create a sub based on the proof claims if the
             # user requests a generated identifier

--- a/oidc-controller/api/core/oidc/issue_token_service.py
+++ b/oidc-controller/api/core/oidc/issue_token_service.py
@@ -96,13 +96,17 @@ class Token(BaseModel):
         # matching the configured subject_identifier, if any
         sub_id_claim = presentation_claims.get(ver_config.subject_identifier)
 
+        pres_req_conf_id_suffix = (
+            f"@{auth_session.request_parameters['pres_req_conf_id']}"
+        )
+
         if sub_id_claim:
             # add sub and append presentation_claims
             assert type(auth_session.request_parameters["pres_req_conf_id"]) == str
             oidc_claims.append(
                 Claim(
                     type="sub",
-                    value=f"{sub_id_claim.value}@{auth_session.request_parameters['pres_req_conf_id']}",
+                    value=sub_id_claim.value + pres_req_conf_id_suffix,
                 )
             )
 
@@ -112,10 +116,7 @@ class Token(BaseModel):
             # Generate a SHA256 hash of the canonicaljson encoded proof_claims
             encoded_json: bytes = canonicaljson.encode_canonical_json(proof_claims)
             sha256_hash = hashlib.sha256(
-                (
-                    encoded_json
-                    + f"@{auth_session.request_parameters['pres_req_conf_id']}".encode()
-                )
+                encoded_json + pres_req_conf_id_suffix.encode()
             ).hexdigest()
             oidc_claims.append(
                 Claim(

--- a/oidc-controller/api/core/oidc/tests/test_issue_token_service.py
+++ b/oidc-controller/api/core/oidc/tests/test_issue_token_service.py
@@ -235,7 +235,7 @@ async def test_valid_presentation_with_matching_subject_identifier_in_claims_sub
     auth_session.presentation_exchange = presentation["by_format"]
     claims = Token.get_claims(auth_session, ver_config)
     print(claims)
-    assert claims["sub"] == "test@email.com"
+    assert claims["sub"] == "test@email.com@verified-email"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR resolves #538 

This resolves overlapping subject identifiers by appending @pres_req_conf_id when generating the sub.