### PR TITLE
[Workflows] Add step to install oc cli

### DIFF
--- a/.github/workflows/on_push_main.yaml
+++ b/.github/workflows/on_push_main.yaml
@@ -34,6 +34,11 @@ jobs:
           sparse-checkout: |
             services
           path: trust-over-ip-configurations
+      
+      - name: Install OpenShift CLI tools
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4.14"
 
       - name: Authenticate and set context
         uses: redhat-actions/oc-login@v1


### PR DESCRIPTION
New version of `ubuntu-latest` no longer includes `oc` cli, causing `oc-login` step to fail.
- Add `openshift-tools-installer` step to workflow