### PR TITLE
Reorg config files

### DIFF
--- a/charts/vc-authn-oidc/templates/configmap.yaml
+++ b/charts/vc-authn-oidc/templates/configmap.yaml
@@ -1,8 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "global.fullname" . }}-session-timeout
+  name: {{ include "global.fullname" . }}-controller-config
   labels: {{- include "vc-authn-oidc.labels" . | nindent 4 }}
 data:
   sessiontimeout.json: |
     {{ .Values.controller.sessionTimeout.config | toJson }}
+  user_variable_substitution.py: |
+    {{ .Values.controller.userVariableSubsitution | nindent 4 }}

--- a/charts/vc-authn-oidc/templates/deployment.yaml
+++ b/charts/vc-authn-oidc/templates/deployment.yaml
@@ -36,15 +36,9 @@ spec:
           secret:
             secretName: {{ include "vc-authn-oidc.token.secretName" . }}
             defaultMode: 256
-        - name: auth-session-ttl
+        - name: controller-config
           configMap:
-            name: {{ include "global.fullname" . }}-session-timeout
-        - name: custom-variable-substitution
-          configMap:
-            name:  {{ include "global.fullname" . }}-variable-substitution-config
-            items:
-              - key: user_variable_substitution.py
-                path: user_variable_substitution.py
+            name: {{ include "global.fullname" . }}-controller-config
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -76,10 +70,10 @@ spec:
               value: {{ .Values.controller.cameraRedirectUrl }}
             - name: CONTROLLER_PRESENTATION_EXPIRE_TIME
               value: {{ .Values.controller.presentationExpireTime | quote }}
-            # - name: CONTROLLER_SESSION_TIMEOUT_CONFIG_FILE
-            #   value: /home/aries/sessiontimeout.json
+            - name: CONTROLLER_SESSION_TIMEOUT_CONFIG_FILE
+              value: /etc/controller-config/sessiontimeout.json
             - name: CONTROLLER_VARIABLE_SUBSTITUTION_OVERRIDE
-              value: /home/aries/user_variable_substitution.py
+              value: /etc/controller-config/user_variable_substitution.py
             - name: CONTROLLER_PRESENTATION_CLEANUP_TIME
               value: {{ .Values.controller.sessionTimeout.duration | quote }}
             - name: ACAPY_AGENT_URL
@@ -138,12 +132,8 @@ spec:
           volumeMounts:
             - name: jwt-token
               mountPath: /opt/token
-            - name: auth-session-ttl
-              mountPath: /home/aries/sessiontimeout.json
-              subPath: sessiontimeout.json
-            - name: custom-variable-substitution
-              mountPath: /home/aries/user_variable_substitution.py
-              subPath: user_variable_substitution.py
+            - name: controller-config
+              mountPath: /etc/controller-config
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/vc-authn-oidc/values.yaml
+++ b/charts/vc-authn-oidc/values.yaml
@@ -40,6 +40,7 @@ walletDeepLinkPrefix: bcwallet://aries_proof-request
 ## @param controller.presentationExpireTime The number of time in seconds a proof request will be valid for
 ## @param controller.sessionTimeout.duration The number of seconds an auth_sessions in the states defined in controllerSessionTimeoutConfig is kept for
 ## @param controller.sessionTimeout.config The json list of auth session states that are safe for deletion
+## @param controller.uservariablesubsitution The placeholder for the user variable substitution file that can be used to add substitution variables
 controller:
   cameraRedirectUrl: wallet_howto
   presentationExpireTime: 300
@@ -49,6 +50,20 @@ controller:
       - expired
       - failed
       - abandoned
+  userVariableSubsitution: |-
+    # This is a default placeholder Python file 
+    # Add any extensions to user variables here. Example below:
+
+    # def sub_days_plus_one(days: str) -> int:
+    # """Strings like '$sub_days_plus_one_4' will be replaced with the
+    # final number incremented by one. In this case 5.
+    # $sub_days_plus_one_4 -> 5
+    # $sub_days_plus_one_10 -> 11"""
+    # return int(days) + 1
+
+    # variable_substitution_map.add_variable_substitution(
+    #     r"\$sub_days_plus_one_(\d+)", sub_days_plus_one
+    # )
 ## @param useHTTPS Prepend Agent and Admin URLs with `https`
 useHTTPS: true
 ## @param logLevel Accepts one of the following values: CRITICAL, ERROR, WARNING, INFO, DEBUG

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -45,8 +45,8 @@ services:
       - 5678:5678
     volumes:
       - ../oidc-controller:/app:rw
-      - ./oidc-controller/config/sessiontimeout.json:/home/aries/sessiontimeout.json
-      - ./oidc-controller/config/user_variable_substitution.py:/home/aries/user_variable_substitution.py
+      - ./oidc-controller/config/sessiontimeout.json:/etc/controller-config/sessiontimeout.json
+      - ./oidc-controller/config/user_variable_substitution.py:/etc/controller-config/user_variable_substitution.py
     networks:
       - vc_auth
 

--- a/docker/manage
+++ b/docker/manage
@@ -177,10 +177,10 @@ configureEnvironment() {
   export CONTROLLER_PRESENTATION_CLEANUP_TIME=86400
 
   # The path to the auth_session timeouts config file
-  export CONTROLLER_SESSION_TIMEOUT_CONFIG_FILE="/home/aries/sessiontimeout.json"
+  export CONTROLLER_SESSION_TIMEOUT_CONFIG_FILE="/etc/controller-config/sessiontimeout.json"
 
   # Extend Variable Substitutions
-  export CONTROLLER_VARIABLE_SUBSTITUTION_OVERRIDE="/home/aries/user_variable_substitution.py"
+  export CONTROLLER_VARIABLE_SUBSTITUTION_OVERRIDE="/etc/controller-config/user_variable_substitution.py"
 
   #controller app settings
   export INVITATION_LABEL=${INVITATION_LABEL:-"VC-AuthN"}


### PR DESCRIPTION
Fix (hopefully) issue with VCAuthN deployment from missing config map. Reorg things so we're just using a single config map instead of intending on one per configuration file. Renamed it "controller-config" instead of specific to "session timeout". Add the "blank" (comments, see below) placeholder user variable sub file to the config map.

Default population for this user variable py file comes from values. So keep the pattern of being able to override it with a values yaml, or operator can have whatever means up updating configmap, or the volume itself, as works for their CICD.
App continues to use environment variable to know which path to look for these files, so can override that as well.

Discussed moving location of files to /app but thinking about that didn't want to volume mount into the directory the code goes into, as that could cause confusion (and if you can alter /app it's like changing the source code anyway instead of "external" configuration), and to keep /app as deployed, built source alone.

Used `/etc/controller-config` instead of `/home/aries`
Don't really care about /etc vs /home but googled practices for config file stuff

> **Best Practices:**
> **System-Wide Configuration**:
> 
> Use the /etc directory for configurations that need to be available to all users or affect system-wide services.
> Keep it organized and maintain proper permissions to ensure system security.
> 
> **User-Specific Configuration**:
> 
> Use the /home directory for configurations that are specific to individual users.
> Store user preferences and application settings in the user’s home directory to avoid conflicts and maintain privacy.

Since this is a system service thing and not a user preference...🤷 again not really important. Important part is to not use "aries" naming any more if we can avoid it. If there's any weird permission thing, or if people think `/home` is a more obvious place to look can change it.

Tested helm install locally on minikube and things seem to be where they're expected (below). But will need to make sure OCP deployment is all good and the Python app doesn't have issues loading.
If we merge this I'll follow through on Dev env and make sure things are deploying ok and the app is picking up the values as expected.

New config map, contains both default file values:
![image](https://github.com/user-attachments/assets/92823a38-7740-471d-85bb-08bdb4725336)

Checking on controller pod:
![image](https://github.com/user-attachments/assets/2d38eb97-aef0-490d-934d-a0027432bb6d)
