### PR TITLE
Corrected dependabot path to pyproject.toml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
   
   # Maintain dependencies for Python packages
   - package-ecosystem: "pip"
-    directory: "/oidc-controller"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
As explained in #740 

I think I've figured it out. The problem arises from https://github.com/Gavinok/vc-authn-oidc/blob/main/.github/dependabot.yml#L16-L26. Since it only looks in /oidc-controller for dependencies, it misses the pyproject.toml altogether.

Using the Dependabot CLI seems to identify multiple dependencies when starting at the root.
~/go/bin/dependabot update pip openwallet-foundation/acapy-vc-authn-oidc

In contrast, identifying a specific directory seems to provide no dependency info at all.
~/go/bin/dependabot update pip openwallet-foundation/acapy-vc-authn-oidc -d /oidc-controller

The solution is to have it check the root of the project for pip dependencies.