### PR TITLE
feat: allow configurable branch or SHA for deployment in workflow

### DIFF
--- a/.github/workflows/on_push_main.yaml
+++ b/.github/workflows/on_push_main.yaml
@@ -1,6 +1,11 @@
 name: Build latest development image
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or full SHA to deploy'
+        required: false
+        default: 'main'
   push:
     branches:
       - main
@@ -16,5 +21,5 @@ jobs:
     if: github.repository_owner == 'openwallet-foundation'
     uses: ./.github/workflows/publish.yml
     with:
-      ref: "main"
+      ref: ${{ inputs.ref }}
       platforms: "linux/amd64,linux/arm64"


### PR DESCRIPTION
Update `on_push_main.yaml` workflow to add `ref` input. Defaults to `main`
`ref` input is then passed to the `Build ACAPy VC-Auth` job.
