### PR TITLE
Adjust main.py tzset call for windows to fix pytest

### DIFF
--- a/oidc-controller/api/main.py
+++ b/oidc-controller/api/main.py
@@ -55,7 +55,9 @@ logging_file_path = os.environ.get(
 
 
 os.environ["TZ"] = settings.TIMEZONE
-time.tzset()
+tzset = getattr(time, "tzset", None)
+if tzset is not None:
+    tzset()
 
 
 def get_application() -> FastAPI:


### PR DESCRIPTION
Addresses https://github.com/openwallet-foundation/acapy-vc-authn-oidc/issues/1036

Guard the Unix-only time.tzset() call in `main.py` so module import no longer crashes on Windows. Unblocks pytest collection for contributors developing on Windows.

The change is behaviorally identical on Linux, which is the only supported runtime (IE the Docker images we publish).

On Linux/macOS, `getattr` returns the real time.tzset and it's invoked exactly as before. So same for prod, CI, and Docker. The only diff is on Windows, where `time.tzset` doesn't exist in CPython at all; there, we now skip the call.

"This is the idiomatic pattern for Unix-only stdlib APIs and is arguably a latent portability fix, not just a test-env convenience: the previous code would have always failed on Windows, it just hadn't been exercised."


