### PR TITLE
Reconnection for SSEs

### DIFF
--- a/html-templates/verified_credentials.html
+++ b/html-templates/verified_credentials.html
@@ -375,23 +375,39 @@
         },
       },
       mounted() {
-        /**
-         * Initialize SSE connection for real-time status updates.
-         * EventSource auto-reconnects natively on disconnect.
-         */
-        const evtSource = new EventSource('/sse/status/{{pid}}');
-        evtSource.addEventListener('status', (e) => {
-          const { status } = JSON.parse(e.data);
-          console.log("SSE status update:", status);
-          this.setUiStates(status);
-          if (['verified', 'failed', 'expired', 'abandoned'].includes(status)) {
-            evtSource.close();
-          }
-        });
-        evtSource.onerror = (e) => {
-          console.error("SSE connection error, will auto-reconnect:", e);
+        // Wrap EventSource setup so we can re-open on visibilitychange. When the
+        // user returns from a wallet deep-link, force an immediate reconnect
+        // instead of waiting for the native EventSource backoff — the server
+        // re-reads DB state on every connect, so this picks up any terminal
+        // status that fired while the tab was backgrounded.
+        const vm = this;
+        const terminalStatuses = ['verified', 'failed', 'expired', 'abandoned'];
+        let evtSource = null;
+
+        const connect = () => {
+          if (evtSource) evtSource.close();
+          evtSource = new EventSource('/sse/status/{{pid}}');
+          evtSource.addEventListener('status', (e) => {
+            const { status } = JSON.parse(e.data);
+            console.log("SSE status update:", status);
+            vm.setUiStates(status);
+            if (terminalStatuses.includes(status)) {
+              evtSource.close();
+              evtSource = null;
+            }
+          });
+          evtSource.onerror = (e) => {
+            console.error("SSE connection error, will auto-reconnect:", e);
+          };
         };
 
+        connect();
+
+        document.addEventListener('visibilitychange', () => {
+          if (document.visibilityState === 'visible' && evtSource !== null) {
+            connect();
+          }
+        });
       },
       delimiters: ["[[", "]]"],
     });

--- a/html-templates/verified_credentials.html
+++ b/html-templates/verified_credentials.html
@@ -376,10 +376,11 @@
       },
       mounted() {
         // Wrap EventSource setup so we can re-open on visibilitychange. When the
-        // user returns from a wallet deep-link, force an immediate reconnect
-        // instead of waiting for the native EventSource backoff — the server
-        // re-reads DB state on every connect, so this picks up any terminal
-        // status that fired while the tab was backgrounded.
+        // user returns from a wallet deep-link, force a reconnect if the
+        // connection is no longer OPEN — the server re-reads DB state on every
+        // connect, so this picks up any terminal status that fired while the
+        // tab was backgrounded. A healthy OPEN connection is left alone to
+        // avoid churn on brief tab switches.
         const vm = this;
         const terminalStatuses = ['verified', 'failed', 'expired', 'abandoned'];
         let evtSource = null;
@@ -401,13 +402,25 @@
           };
         };
 
-        connect();
-
-        document.addEventListener('visibilitychange', () => {
-          if (document.visibilityState === 'visible' && evtSource !== null) {
+        const onVisibilityChange = () => {
+          if (
+            document.visibilityState === 'visible' &&
+            evtSource !== null &&
+            evtSource.readyState !== EventSource.OPEN
+          ) {
             connect();
           }
-        });
+        };
+
+        connect();
+        document.addEventListener('visibilitychange', onVisibilityChange);
+        this._sseVisibilityHandler = onVisibilityChange;
+        this._sseGetEvtSource = () => evtSource;
+      },
+      beforeUnmount() {
+        document.removeEventListener('visibilitychange', this._sseVisibilityHandler);
+        const evtSource = this._sseGetEvtSource && this._sseGetEvtSource();
+        if (evtSource) evtSource.close();
       },
       delimiters: ["[[", "]]"],
     });

--- a/oidc-controller/api/routers/sse.py
+++ b/oidc-controller/api/routers/sse.py
@@ -264,6 +264,16 @@ async def _sse_event_loop(
         pid, db
     )
     if status is not None:
+        # Last-Event-ID presence signals browser reconnect. We don't use the
+        # value (DB is source of truth), but logging it confirms the
+        # mobile-backgrounding recovery path is working in production.
+        if is_terminal:
+            logger.info(
+                "SSE initial-state emit is terminal",
+                pid=pid,
+                status=status,
+                is_reconnect=request.headers.get("last-event-id") is not None,
+            )
         yield _format_event({"status": status}, id=str(seq))
         seq += 1
         if is_terminal:

--- a/oidc-controller/api/routers/sse.py
+++ b/oidc-controller/api/routers/sse.py
@@ -265,14 +265,15 @@ async def _sse_event_loop(
     )
     if status is not None:
         # Last-Event-ID presence signals browser reconnect. We don't use the
-        # value (DB is source of truth), but logging it confirms the
-        # mobile-backgrounding recovery path is working in production.
-        if is_terminal:
+        # value (DB is source of truth), but logging when a reconnect lands on
+        # a terminal status confirms the mobile-backgrounding recovery path is
+        # working. First-time terminal-on-connect is the normal flow, so it is
+        # not logged here to keep volume low.
+        if is_terminal and request.headers.get("last-event-id") is not None:
             logger.info(
-                "SSE initial-state emit is terminal",
+                "SSE reconnect delivered terminal status",
                 pid=pid,
-                status=status,
-                is_reconnect=request.headers.get("last-event-id") is not None,
+                status=status.value,
             )
         yield _format_event({"status": status}, id=str(seq))
         seq += 1

--- a/oidc-controller/api/routers/tests/test_sse.py
+++ b/oidc-controller/api/routers/tests/test_sse.py
@@ -997,15 +997,13 @@ class TestSseOnlyExpiry:
 
 
 class TestReconnectAfterStatusChange:
-    """Simulates the mobile backgrounding flow:
+    """Covers the mobile backgrounding flow without relying on streaming:
 
-    1. Client opens SSE stream in NOT_STARTED.
-    2. Tab backgrounds → SSE connection drops (server-side it just ends).
-    3. ACA-Py webhook arrives while no subscriber is live; DB flips to
-       terminal status and notify() publishes (delivered to no one).
-    4. Tab returns → native EventSource (or visibilitychange handler)
-       reconnects, sending the Last-Event-ID header.
-    5. Server reads current DB state, emits the terminal status, closes.
+    The two pieces that matter are independent of any prior connection state:
+    1. notify() with no subscriber must drop cleanly (no leak).
+    2. A connect that carries Last-Event-ID returns the current DB status —
+       the mechanism by which a reconnecting browser recovers a missed event.
+    Plus structured logging so we can audit the recovery path in production.
     """
 
     def setup_method(self):
@@ -1018,56 +1016,42 @@ class TestReconnectAfterStatusChange:
         _latest.clear()
         sse_module._redis_client = None
 
-    def test_reconnect_single_pod_receives_terminal_status_after_missed_notify(self):
-        app = _make_app()
-        not_started = _make_auth_session(AuthSessionState.NOT_STARTED)
-        not_started.expired_timestamp = datetime.now(UTC) + timedelta(seconds=300)
-        verified = _make_auth_session(AuthSessionState.VERIFIED)
+    @pytest.mark.asyncio
+    async def test_single_pod_notify_with_no_subscriber_is_dropped(self):
+        """In single-pod mode, notify() while no subscriber is registered must
+        not store anything (otherwise _latest leaks). The reconnecting client
+        relies on the DB read instead."""
+        with patch.object(sse_module.settings, "REDIS_MODE", "none"):
+            await notify("missing-pid", "verified")
+        assert "missing-pid" not in _latest
+        assert "missing-pid" not in _signals
 
+    def test_reconnect_with_last_event_id_emits_terminal_from_db(self):
+        """Single-pod: a reconnecting client (Last-Event-ID header set) gets the
+        terminal status from the DB even though the earlier notify() was
+        dropped because no subscriber was live."""
+        app = _make_app()
         mock_crud = MagicMock()
-        # Connect #1 reads NOT_STARTED; in between the DB flips; Connect #2
-        # reads VERIFIED.
-        mock_crud.get = AsyncMock(side_effect=[not_started, not_started, verified])
-        mock_crud.patch = AsyncMock()
+        mock_crud.get = AsyncMock(
+            return_value=_make_auth_session(AuthSessionState.VERIFIED)
+        )
 
         with patch("api.routers.sse.AuthSessionCRUD", return_value=mock_crud):
             with patch("api.routers.sse.settings") as mock_settings:
                 mock_settings.REDIS_MODE = "none"
                 client = TestClient(app, raise_server_exceptions=False)
-
-                # Connect #1 — client sees the initial NOT_STARTED state and
-                # closes (simulating tab backgrounding). The client does NOT
-                # fully consume the stream because the while loop would block
-                # on the wait_fn; closing the TestClient context ends it.
-                with client.stream(
-                    "GET", "/sse/status/507f1f77bcf86cd799439011"
-                ) as resp1:
-                    assert resp1.status_code == 200
-                    # Read just enough to confirm initial state arrived.
-                    chunks = []
-                    for chunk in resp1.iter_bytes():
-                        chunks.append(chunk)
-                        if b"not_started" in b"".join(chunks):
-                            break
-                    assert b"not_started" in b"".join(chunks)
-
-                # Simulate a missed notify() while backgrounded — nothing is
-                # listening, so _latest/_signals stays empty. This is exactly
-                # what happens in the real flow.
-                #
-                # Connect #2 — browser reconnects with Last-Event-ID header.
-                # Server reads DB (now VERIFIED), emits verified, closes.
-                resp2 = client.get(
+                resp = client.get(
                     "/sse/status/507f1f77bcf86cd799439011",
                     headers={"Last-Event-ID": "0"},
                 )
-                assert resp2.status_code == 200
-                assert b"verified" in resp2.content
 
-    def test_terminal_on_connect_logs_is_reconnect_from_last_event_id_header(self):
+        assert resp.status_code == 200
+        assert b"verified" in resp.content
+
+    def test_reconnect_with_terminal_status_emits_audit_log(self):
         """When Last-Event-ID is present and the initial state is terminal, the
-        structured log records is_reconnect=True so production traffic can be
-        audited for the mobile backgrounding recovery path."""
+        structured log fires so production traffic can be audited for the
+        mobile backgrounding recovery path."""
         app = _make_app()
         mock_crud = MagicMock()
         mock_crud.get = AsyncMock(
@@ -1093,14 +1077,15 @@ class TestReconnectAfterStatusChange:
         terminal_logs = [
             kwargs
             for msg, kwargs in log_calls
-            if "SSE initial-state emit is terminal" in msg
+            if "SSE reconnect delivered terminal status" in msg
         ]
         assert len(terminal_logs) == 1
-        assert terminal_logs[0]["is_reconnect"] is True
-        assert terminal_logs[0]["status"] == AuthSessionState.VERIFIED
+        assert terminal_logs[0]["status"] == AuthSessionState.VERIFIED.value
 
-    def test_terminal_on_connect_logs_is_reconnect_false_without_header(self):
-        """First-time connect (no Last-Event-ID) logs is_reconnect=False."""
+    def test_first_connect_with_terminal_status_does_not_emit_audit_log(self):
+        """First-time connect (no Last-Event-ID) is the normal flow and must
+        not emit the reconnect audit log — that log is reserved for the
+        mobile-backgrounding recovery path to keep volume low."""
         app = _make_app()
         mock_crud = MagicMock()
         mock_crud.get = AsyncMock(
@@ -1123,22 +1108,19 @@ class TestReconnectAfterStatusChange:
         terminal_logs = [
             kwargs
             for msg, kwargs in log_calls
-            if "SSE initial-state emit is terminal" in msg
+            if "SSE reconnect delivered terminal status" in msg
         ]
-        assert len(terminal_logs) == 1
-        assert terminal_logs[0]["is_reconnect"] is False
+        assert len(terminal_logs) == 0
 
-    def test_reconnect_multi_pod_receives_terminal_status_after_missed_notify(self):
-        """Multi-pod variant: Redis pub/sub publish during disconnect is lost,
-        but reconnect reads DB and delivers terminal status."""
+    def test_multi_pod_reconnect_with_last_event_id_emits_terminal_from_db(self):
+        """Multi-pod: even with Redis pub/sub configured, a reconnecting client
+        is served the terminal status from the DB on the initial-state emit
+        before the subscribe loop ever needs to deliver anything."""
         app = _make_app()
-        not_started = _make_auth_session(AuthSessionState.NOT_STARTED)
-        not_started.expired_timestamp = datetime.now(UTC) + timedelta(seconds=300)
-        verified = _make_auth_session(AuthSessionState.VERIFIED)
-
         mock_crud = MagicMock()
-        mock_crud.get = AsyncMock(side_effect=[not_started, not_started, verified])
-        mock_crud.patch = AsyncMock()
+        mock_crud.get = AsyncMock(
+            return_value=_make_auth_session(AuthSessionState.VERIFIED)
+        )
 
         mock_redis = MagicMock()
         mock_pubsub = MagicMock()
@@ -1146,28 +1128,16 @@ class TestReconnectAfterStatusChange:
         mock_pubsub.subscribe = AsyncMock()
         mock_pubsub.unsubscribe = AsyncMock()
         mock_pubsub.aclose = AsyncMock()
-        mock_pubsub.get_message = AsyncMock(return_value=None)
         sse_module._redis_client = mock_redis
 
         with patch("api.routers.sse.AuthSessionCRUD", return_value=mock_crud):
             with patch("api.routers.sse.settings") as mock_settings:
                 mock_settings.REDIS_MODE = "single"
                 client = TestClient(app, raise_server_exceptions=False)
-
-                with client.stream(
-                    "GET", "/sse/status/507f1f77bcf86cd799439011"
-                ) as resp1:
-                    assert resp1.status_code == 200
-                    chunks = []
-                    for chunk in resp1.iter_bytes():
-                        chunks.append(chunk)
-                        if b"not_started" in b"".join(chunks):
-                            break
-                    assert b"not_started" in b"".join(chunks)
-
-                resp2 = client.get(
+                resp = client.get(
                     "/sse/status/507f1f77bcf86cd799439011",
                     headers={"Last-Event-ID": "0"},
                 )
-                assert resp2.status_code == 200
-                assert b"verified" in resp2.content
+
+        assert resp.status_code == 200
+        assert b"verified" in resp.content

--- a/oidc-controller/api/routers/tests/test_sse.py
+++ b/oidc-controller/api/routers/tests/test_sse.py
@@ -1082,9 +1082,7 @@ class TestReconnectAfterStatusChange:
         with patch("api.routers.sse.AuthSessionCRUD", return_value=mock_crud):
             with patch("api.routers.sse.settings") as mock_settings:
                 mock_settings.REDIS_MODE = "none"
-                with patch.object(
-                    sse_module.logger, "info", side_effect=capture_info
-                ):
+                with patch.object(sse_module.logger, "info", side_effect=capture_info):
                     client = TestClient(app, raise_server_exceptions=False)
                     resp = client.get(
                         "/sse/status/507f1f77bcf86cd799439011",
@@ -1117,9 +1115,7 @@ class TestReconnectAfterStatusChange:
         with patch("api.routers.sse.AuthSessionCRUD", return_value=mock_crud):
             with patch("api.routers.sse.settings") as mock_settings:
                 mock_settings.REDIS_MODE = "none"
-                with patch.object(
-                    sse_module.logger, "info", side_effect=capture_info
-                ):
+                with patch.object(sse_module.logger, "info", side_effect=capture_info):
                     client = TestClient(app, raise_server_exceptions=False)
                     resp = client.get("/sse/status/507f1f77bcf86cd799439011")
 

--- a/oidc-controller/api/routers/tests/test_sse.py
+++ b/oidc-controller/api/routers/tests/test_sse.py
@@ -989,3 +989,189 @@ class TestSseOnlyExpiry:
         assert b"expired" in resp.content
         # DB was patched — expiry was handled server-side via SSE, not polling
         mock_crud.patch.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: reconnect-after-terminal-status (mobile backgrounding)
+# ---------------------------------------------------------------------------
+
+
+class TestReconnectAfterStatusChange:
+    """Simulates the mobile backgrounding flow:
+
+    1. Client opens SSE stream in NOT_STARTED.
+    2. Tab backgrounds → SSE connection drops (server-side it just ends).
+    3. ACA-Py webhook arrives while no subscriber is live; DB flips to
+       terminal status and notify() publishes (delivered to no one).
+    4. Tab returns → native EventSource (or visibilitychange handler)
+       reconnects, sending the Last-Event-ID header.
+    5. Server reads current DB state, emits the terminal status, closes.
+    """
+
+    def setup_method(self):
+        _signals.clear()
+        _latest.clear()
+        sse_module._redis_client = None
+
+    def teardown_method(self):
+        _signals.clear()
+        _latest.clear()
+        sse_module._redis_client = None
+
+    def test_reconnect_single_pod_receives_terminal_status_after_missed_notify(self):
+        app = _make_app()
+        not_started = _make_auth_session(AuthSessionState.NOT_STARTED)
+        not_started.expired_timestamp = datetime.now(UTC) + timedelta(seconds=300)
+        verified = _make_auth_session(AuthSessionState.VERIFIED)
+
+        mock_crud = MagicMock()
+        # Connect #1 reads NOT_STARTED; in between the DB flips; Connect #2
+        # reads VERIFIED.
+        mock_crud.get = AsyncMock(side_effect=[not_started, not_started, verified])
+        mock_crud.patch = AsyncMock()
+
+        with patch("api.routers.sse.AuthSessionCRUD", return_value=mock_crud):
+            with patch("api.routers.sse.settings") as mock_settings:
+                mock_settings.REDIS_MODE = "none"
+                client = TestClient(app, raise_server_exceptions=False)
+
+                # Connect #1 — client sees the initial NOT_STARTED state and
+                # closes (simulating tab backgrounding). The client does NOT
+                # fully consume the stream because the while loop would block
+                # on the wait_fn; closing the TestClient context ends it.
+                with client.stream(
+                    "GET", "/sse/status/507f1f77bcf86cd799439011"
+                ) as resp1:
+                    assert resp1.status_code == 200
+                    # Read just enough to confirm initial state arrived.
+                    chunks = []
+                    for chunk in resp1.iter_bytes():
+                        chunks.append(chunk)
+                        if b"not_started" in b"".join(chunks):
+                            break
+                    assert b"not_started" in b"".join(chunks)
+
+                # Simulate a missed notify() while backgrounded — nothing is
+                # listening, so _latest/_signals stays empty. This is exactly
+                # what happens in the real flow.
+                #
+                # Connect #2 — browser reconnects with Last-Event-ID header.
+                # Server reads DB (now VERIFIED), emits verified, closes.
+                resp2 = client.get(
+                    "/sse/status/507f1f77bcf86cd799439011",
+                    headers={"Last-Event-ID": "0"},
+                )
+                assert resp2.status_code == 200
+                assert b"verified" in resp2.content
+
+    def test_terminal_on_connect_logs_is_reconnect_from_last_event_id_header(self):
+        """When Last-Event-ID is present and the initial state is terminal, the
+        structured log records is_reconnect=True so production traffic can be
+        audited for the mobile backgrounding recovery path."""
+        app = _make_app()
+        mock_crud = MagicMock()
+        mock_crud.get = AsyncMock(
+            return_value=_make_auth_session(AuthSessionState.VERIFIED)
+        )
+
+        log_calls = []
+
+        def capture_info(msg, **kwargs):
+            log_calls.append((msg, kwargs))
+
+        with patch("api.routers.sse.AuthSessionCRUD", return_value=mock_crud):
+            with patch("api.routers.sse.settings") as mock_settings:
+                mock_settings.REDIS_MODE = "none"
+                with patch.object(
+                    sse_module.logger, "info", side_effect=capture_info
+                ):
+                    client = TestClient(app, raise_server_exceptions=False)
+                    resp = client.get(
+                        "/sse/status/507f1f77bcf86cd799439011",
+                        headers={"Last-Event-ID": "42"},
+                    )
+
+        assert resp.status_code == 200
+        terminal_logs = [
+            kwargs
+            for msg, kwargs in log_calls
+            if "SSE initial-state emit is terminal" in msg
+        ]
+        assert len(terminal_logs) == 1
+        assert terminal_logs[0]["is_reconnect"] is True
+        assert terminal_logs[0]["status"] == AuthSessionState.VERIFIED
+
+    def test_terminal_on_connect_logs_is_reconnect_false_without_header(self):
+        """First-time connect (no Last-Event-ID) logs is_reconnect=False."""
+        app = _make_app()
+        mock_crud = MagicMock()
+        mock_crud.get = AsyncMock(
+            return_value=_make_auth_session(AuthSessionState.VERIFIED)
+        )
+
+        log_calls = []
+
+        def capture_info(msg, **kwargs):
+            log_calls.append((msg, kwargs))
+
+        with patch("api.routers.sse.AuthSessionCRUD", return_value=mock_crud):
+            with patch("api.routers.sse.settings") as mock_settings:
+                mock_settings.REDIS_MODE = "none"
+                with patch.object(
+                    sse_module.logger, "info", side_effect=capture_info
+                ):
+                    client = TestClient(app, raise_server_exceptions=False)
+                    resp = client.get("/sse/status/507f1f77bcf86cd799439011")
+
+        assert resp.status_code == 200
+        terminal_logs = [
+            kwargs
+            for msg, kwargs in log_calls
+            if "SSE initial-state emit is terminal" in msg
+        ]
+        assert len(terminal_logs) == 1
+        assert terminal_logs[0]["is_reconnect"] is False
+
+    def test_reconnect_multi_pod_receives_terminal_status_after_missed_notify(self):
+        """Multi-pod variant: Redis pub/sub publish during disconnect is lost,
+        but reconnect reads DB and delivers terminal status."""
+        app = _make_app()
+        not_started = _make_auth_session(AuthSessionState.NOT_STARTED)
+        not_started.expired_timestamp = datetime.now(UTC) + timedelta(seconds=300)
+        verified = _make_auth_session(AuthSessionState.VERIFIED)
+
+        mock_crud = MagicMock()
+        mock_crud.get = AsyncMock(side_effect=[not_started, not_started, verified])
+        mock_crud.patch = AsyncMock()
+
+        mock_redis = MagicMock()
+        mock_pubsub = MagicMock()
+        mock_redis.pubsub.return_value = mock_pubsub
+        mock_pubsub.subscribe = AsyncMock()
+        mock_pubsub.unsubscribe = AsyncMock()
+        mock_pubsub.aclose = AsyncMock()
+        mock_pubsub.get_message = AsyncMock(return_value=None)
+        sse_module._redis_client = mock_redis
+
+        with patch("api.routers.sse.AuthSessionCRUD", return_value=mock_crud):
+            with patch("api.routers.sse.settings") as mock_settings:
+                mock_settings.REDIS_MODE = "single"
+                client = TestClient(app, raise_server_exceptions=False)
+
+                with client.stream(
+                    "GET", "/sse/status/507f1f77bcf86cd799439011"
+                ) as resp1:
+                    assert resp1.status_code == 200
+                    chunks = []
+                    for chunk in resp1.iter_bytes():
+                        chunks.append(chunk)
+                        if b"not_started" in b"".join(chunks):
+                            break
+                    assert b"not_started" in b"".join(chunks)
+
+                resp2 = client.get(
+                    "/sse/status/507f1f77bcf86cd799439011",
+                    headers={"Last-Event-ID": "0"},
+                )
+                assert resp2.status_code == 200
+                assert b"verified" in resp2.content


### PR DESCRIPTION
When a user returns to the verification page after a wallet deep-link backgrounded the tab, force an immediate `EventSource` reconnect instead of waiting on the browser's native backoff.

The page now wraps `EventSource` setup in a connect() helper and listens for `visibilitychange`: when the tab becomes visible again and a connection is still open, it closes and reopens the stream. On each new connection the server's _sse_event_loop re-reads proof status from the DB and emits it as the initial event, so reconnecting deterministically resyncs state — including any terminal status (**verified / failed / expired / abandoned**) that fired while the tab was hidden and was missed by the suspended EventSource. Once a terminal status is received, the client closes the stream and stops reconnecting.

Adds a log line on terminal initial-state emits (with a `last-event-id` reconnect flag) to confirm the recovery path in prod, plus tests for the SSE router.

